### PR TITLE
Add Monotum, TUM VI, and 4Seasons datasets + streamline abstractions

### DIFF
--- a/Datasets/DatasetVSLAMLab.py
+++ b/Datasets/DatasetVSLAMLab.py
@@ -14,7 +14,7 @@ import sys
 import yaml
 from loguru import logger
 from pathlib import Path
-from typing import List, Union
+from typing import Any, List, Union
 from abc import ABC, abstractmethod
 
 from utilities import ws, print_msg
@@ -49,11 +49,14 @@ class DatasetVSLAMLab(ABC):
         with open(self.yaml_file, "r", encoding="utf-8") as f:
             cfg = yaml.safe_load(f) or {}
 
-        self.sequence_names: List[str] = cfg["sequence_names"]
-        self.rgb_hz: float = float(cfg["rgb_hz"])
-        self.modes: List[str] = cfg.get("modes", ["mono"])
+        # Keep raw YAML config accessible to subclasses.
+        self.cfg: dict[str, Any] = cfg
+
+        self.sequence_names: List[str] = self.cfg["sequence_names"]
+        self.rgb_hz: float = float(self.cfg["rgb_hz"])
+        self.modes: List[str] = self.cfg.get("modes", ["mono"])
         self.sequence_nicknames: List[str] = []
-        self.cam_models: List[str] = cfg.get("cam_models", ["pinhole"])
+        self.cam_models: List[str] = self.cfg.get("cam_models", ["pinhole"])
         
     @abstractmethod
     def download_sequence_data(self, sequence_name: str) -> None: ...
@@ -165,6 +168,14 @@ class DatasetVSLAMLab(ABC):
 
     ####################################################################################################################
     # Utils
+
+    def cfg_get(self, key: str, default: Any = None) -> Any:
+        return self.cfg.get(key, default)
+
+    def cfg_require(self, key: str) -> Any:
+        if key not in self.cfg:
+            raise KeyError(f"Missing required key '{key}' in {self.yaml_file}")
+        return self.cfg[key]
 
     def contains_sequence(self, sequence_name_ref: str) -> bool:
         return sequence_name_ref in self.sequence_names

--- a/Datasets/dataset_files/dataset_4seasons.py
+++ b/Datasets/dataset_files/dataset_4seasons.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import csv
+import re
+import shutil
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin
+
+import numpy as np
+import pandas as pd
+import yaml
+
+from Datasets.DatasetVSLAMLab import DatasetVSLAMLab
+from path_constants import BENCHMARK_RETENTION, Retention
+from utilities import decompressFile, downloadFile
+
+
+class FOURSEASONS_dataset(DatasetVSLAMLab):
+    """4Seasons dataset helper for VSLAM-LAB benchmark."""
+
+    def __init__(self, benchmark_path: str | Path, dataset_name: str = "4seasons") -> None:
+        super().__init__(dataset_name, Path(benchmark_path))
+
+        self.url_download_root: str = self.cfg_require("url_download_root")
+        self.recordings: dict[str, str] = self.cfg_require("recordings")
+        self.with_reference_poses: list[str] = list(self.cfg_get("with_reference_poses", []))
+        self.imu_hz: float = float(self.cfg_get("imu_hz", 200.0))
+        self.sequence_nicknames = [s.replace("_", " ") for s in self.sequence_names]
+
+    def download_sequence_data(self, sequence_name: str) -> None:
+        rec = self._recording(sequence_name)
+        sequence_path = self.dataset_path / sequence_name
+        if sequence_path.exists():
+            return
+
+        # Download sequence assets (IMU + undistorted stereo + optional reference poses).
+        assets = [
+            f"{rec}_imu_gnss.zip",
+            f"{rec}_stereo_images_undistorted.zip",
+        ]
+        if sequence_name in self.with_reference_poses:
+            assets.append(f"{rec}_reference_poses.zip")
+
+        for asset in assets:
+            url = urljoin(self.url_download_root.rstrip("/") + "/", f"{rec}/{asset}")
+            archive = self.dataset_path / asset
+            if not archive.exists():
+                downloadFile(url, str(self.dataset_path))
+            decompressFile(str(archive), str(self.dataset_path))
+
+    def create_rgb_folder(self, sequence_name: str) -> None:
+        sequence_path = self.dataset_path / sequence_name
+        sequence_path.mkdir(parents=True, exist_ok=True)
+
+        rec = self._recording(sequence_name)
+        root = self._find_recording_root(rec)
+        cam0_src, cam1_src = self._find_stereo_dirs(root)
+
+        rgb0 = sequence_path / "rgb_0"
+        rgb1 = sequence_path / "rgb_1"
+
+        if not rgb0.exists():
+            rgb0.symlink_to(cam0_src, target_is_directory=True)
+        if not rgb1.exists():
+            rgb1.symlink_to(cam1_src, target_is_directory=True)
+
+    def create_rgb_csv(self, sequence_name: str) -> None:
+        sequence_path = self.dataset_path / sequence_name
+        rgb_csv = sequence_path / "rgb.csv"
+        if rgb_csv.exists():
+            return
+
+        rgb0 = sequence_path / "rgb_0"
+        rgb1 = sequence_path / "rgb_1"
+        files0 = sorted([p.name for p in rgb0.iterdir() if p.is_file() and p.suffix.lower() in {".png", ".jpg", ".jpeg"}])
+        files1 = sorted([p.name for p in rgb1.iterdir() if p.is_file() and p.suffix.lower() in {".png", ".jpg", ".jpeg"}])
+
+        # Use common filenames when available; otherwise zip by index.
+        common = sorted(set(files0).intersection(files1))
+        rows: list[tuple[int, str, int, str]] = []
+        if common:
+            for name in common:
+                ts_ns = self._timestamp_from_filename(name)
+                rows.append((ts_ns, f"rgb_0/{name}", ts_ns, f"rgb_1/{name}"))
+        else:
+            n = min(len(files0), len(files1))
+            for i in range(n):
+                ts0 = self._timestamp_from_filename(files0[i])
+                ts1 = self._timestamp_from_filename(files1[i])
+                rows.append((ts0, f"rgb_0/{files0[i]}", ts1, f"rgb_1/{files1[i]}"))
+
+        tmp = rgb_csv.with_suffix(".csv.tmp")
+        with open(tmp, "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(["ts_rgb_0 (ns)", "path_rgb_0", "ts_rgb_1 (ns)", "path_rgb_1"])
+            w.writerows(rows)
+        tmp.replace(rgb_csv)
+
+    def create_imu_csv(self, sequence_name: str) -> None:
+        rec = self._recording(sequence_name)
+        root = self._find_recording_root(rec)
+        src = self._find_imu_csv(root)
+        dst = self.dataset_path / sequence_name / "imu_0.csv"
+
+        if not src.exists():
+            return
+        if dst.exists() and dst.stat().st_mtime >= src.stat().st_mtime:
+            return
+
+        # Parse numeric rows robustly from comma/space separated logs.
+        df = pd.read_csv(src, comment="#", header=None, sep=r"[\s,]+", engine="python")
+        if df.empty or df.shape[1] < 7:
+            return
+        num = df.apply(pd.to_numeric, errors="coerce")
+        num = num.dropna(subset=[0, 1, 2, 3, 4, 5, 6])
+        if num.empty:
+            return
+
+        ts = num.iloc[:, 0].astype(np.float64)
+        ts_ns = ts.astype(np.int64) if ts.median() > 1e12 else (ts * 1e9).astype(np.int64)
+        out = pd.DataFrame(
+            {
+                "ts (ns)": ts_ns,
+                "wx (rad s^-1)": num.iloc[:, 1],
+                "wy (rad s^-1)": num.iloc[:, 2],
+                "wz (rad s^-1)": num.iloc[:, 3],
+                "ax (m s^-2)": num.iloc[:, 4],
+                "ay (m s^-2)": num.iloc[:, 5],
+                "az (m s^-2)": num.iloc[:, 6],
+            }
+        )
+        tmp = dst.with_suffix(".csv.tmp")
+        out.to_csv(tmp, index=False)
+        tmp.replace(dst)
+
+    def create_calibration_yaml(self, sequence_name: str) -> None:
+        rec = self._recording(sequence_name)
+        root = self._find_recording_root(rec)
+        cam0, cam1 = self._load_camera_params(root)
+
+        rgb0: dict[str, Any] = {
+            "cam_name": "rgb_0",
+            "cam_type": "gray",
+            "cam_model": cam0.get("cam_model", "pinhole"),
+            "focal_length": cam0["focal_length"],
+            "principal_point": cam0["principal_point"],
+            "fps": float(self.rgb_hz),
+            "T_BS": cam0.get("T_BS", np.eye(4)),
+        }
+        if "distortion_type" in cam0:
+            rgb0["distortion_type"] = cam0["distortion_type"]
+            rgb0["distortion_coefficients"] = cam0.get("distortion_coefficients", [])
+
+        rgb1: dict[str, Any] = {
+            "cam_name": "rgb_1",
+            "cam_type": "gray",
+            "cam_model": cam1.get("cam_model", "pinhole"),
+            "focal_length": cam1["focal_length"],
+            "principal_point": cam1["principal_point"],
+            "fps": float(self.rgb_hz),
+            "T_BS": cam1.get("T_BS", np.eye(4)),
+        }
+        if "distortion_type" in cam1:
+            rgb1["distortion_type"] = cam1["distortion_type"]
+            rgb1["distortion_coefficients"] = cam1.get("distortion_coefficients", [])
+
+        imu0: dict[str, Any] = {
+            "imu_name": "imu_0",
+            "a_max": 176.0,
+            "g_max": 7.8,
+            "sigma_g_c": 2.0e-4,
+            "sigma_a_c": 2.0e-3,
+            "sigma_bg": 1.0e-2,
+            "sigma_ba": 1.0e-1,
+            "sigma_gw_c": 2.0e-5,
+            "sigma_aw_c": 2.0e-3,
+            "g": 9.81007,
+            "g0": [0.0, 0.0, 0.0],
+            "a0": [0.0, 0.0, 0.0],
+            "s_a": [1.0, 1.0, 1.0],
+            "fps": float(self.imu_hz),
+            "T_BS": np.eye(4),
+        }
+        self.write_calibration_yaml(sequence_name=sequence_name, rgb=[rgb0, rgb1], imu=[imu0])
+
+    def create_groundtruth_csv(self, sequence_name: str) -> None:
+        if sequence_name not in self.with_reference_poses:
+            return
+
+        rec = self._recording(sequence_name)
+        root = self._find_recording_root(rec)
+        src = self._find_reference_pose_csv(root)
+        if src is None:
+            return
+
+        dst = self.dataset_path / sequence_name / "groundtruth.csv"
+        tmp = dst.with_suffix(".csv.tmp")
+
+        df = pd.read_csv(src, comment="#")
+        # Try named columns first.
+        col_map = {c.lower().strip(): c for c in df.columns}
+
+        def col(*names: str) -> str | None:
+            for n in names:
+                if n in col_map:
+                    return col_map[n]
+            return None
+
+        ts_c = col("timestamp", "ts", "time", "timestamp_ns", "t")
+        tx_c = col("tx", "px", "x")
+        ty_c = col("ty", "py", "y")
+        tz_c = col("tz", "pz", "z")
+        qx_c = col("qx")
+        qy_c = col("qy")
+        qz_c = col("qz")
+        qw_c = col("qw")
+
+        out_rows: list[list[Any]] = []
+        if all(v is not None for v in (ts_c, tx_c, ty_c, tz_c, qx_c, qy_c, qz_c, qw_c)):
+            for _, r in df.iterrows():
+                vals = [r[ts_c], r[tx_c], r[ty_c], r[tz_c], r[qx_c], r[qy_c], r[qz_c], r[qw_c]]
+                if any(pd.isna(v) for v in vals):
+                    continue
+                ts = float(vals[0])
+                ts_ns = int(ts if ts > 1e12 else ts * 1e9)
+                out_rows.append([ts_ns, float(vals[1]), float(vals[2]), float(vals[3]), float(vals[4]), float(vals[5]), float(vals[6]), float(vals[7])])
+        else:
+            # Fallback numeric parse.
+            num = df.apply(pd.to_numeric, errors="coerce")
+            num = num.dropna()
+            for _, r in num.iterrows():
+                if len(r) < 8:
+                    continue
+                ts = float(r.iloc[0])
+                ts_ns = int(ts if ts > 1e12 else ts * 1e9)
+                out_rows.append([ts_ns, float(r.iloc[1]), float(r.iloc[2]), float(r.iloc[3]), float(r.iloc[4]), float(r.iloc[5]), float(r.iloc[6]), float(r.iloc[7])])
+
+        with open(tmp, "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(["ts (ns)", "tx (m)", "ty (m)", "tz (m)", "qx", "qy", "qz", "qw"])
+            w.writerows(out_rows)
+        tmp.replace(dst)
+
+    def remove_unused_files(self, sequence_name: str) -> None:
+        if BENCHMARK_RETENTION == Retention.MINIMAL:
+            rec = self._recording(sequence_name)
+            for suffix in ("_imu_gnss.zip", "_stereo_images_undistorted.zip", "_reference_poses.zip"):
+                (self.dataset_path / f"{rec}{suffix}").unlink(missing_ok=True)
+
+    def _recording(self, sequence_name: str) -> str:
+        if sequence_name not in self.recordings:
+            raise KeyError(f"Unknown 4seasons sequence '{sequence_name}'")
+        return self.recordings[sequence_name]
+
+    def _find_recording_root(self, recording: str) -> Path:
+        direct = self.dataset_path / recording
+        if direct.exists():
+            return direct
+        matches = [p for p in self.dataset_path.rglob(recording) if p.is_dir()]
+        if matches:
+            return matches[0]
+        return self.dataset_path
+
+    @staticmethod
+    def _timestamp_from_filename(filename: str) -> int:
+        stem = Path(filename).stem
+        try:
+            ts = float(stem)
+            return int(ts if ts > 1e12 else ts * 1e9)
+        except ValueError:
+            # deterministic fallback if filenames are not timestamp-based
+            return 0
+
+    @staticmethod
+    def _find_stereo_dirs(root: Path) -> tuple[Path, Path]:
+        candidates0 = [p for p in root.rglob("*") if p.is_dir() and p.name in {"cam0", "left"}]
+        candidates1 = [p for p in root.rglob("*") if p.is_dir() and p.name in {"cam1", "right"}]
+        if not candidates0 or not candidates1:
+            raise FileNotFoundError(f"Could not locate stereo camera folders under {root}")
+        # Prefer folders with image files.
+        def score(p: Path) -> int:
+            return sum(1 for _ in p.glob("*.png")) + sum(1 for _ in p.glob("*.jpg"))
+        cam0 = sorted(candidates0, key=score, reverse=True)[0]
+        cam1 = sorted(candidates1, key=score, reverse=True)[0]
+        return cam0, cam1
+
+    @staticmethod
+    def _find_imu_csv(root: Path) -> Path:
+        candidates = []
+        for pattern in ("*imu*.csv", "*imu*.txt"):
+            candidates.extend([p for p in root.rglob(pattern) if p.is_file()])
+        if not candidates:
+            raise FileNotFoundError(f"Could not find IMU CSV under {root}")
+        # Prefer explicit imu_gnss file names.
+        candidates.sort(key=lambda p: (0 if "imu_gnss" in p.name else 1, len(str(p))))
+        return candidates[0]
+
+    @staticmethod
+    def _find_reference_pose_csv(root: Path) -> Path | None:
+        patterns = ("*reference*pose*.csv", "*reference*poses*.txt", "*poses*.csv")
+        for pat in patterns:
+            matches = [p for p in root.rglob(pat) if p.is_file()]
+            if matches:
+                return matches[0]
+        return None
+
+    @staticmethod
+    def _load_camera_params(root: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+        cam0_yaml = next(iter([p for p in root.rglob("cam0/sensor.yaml") if p.is_file()]), None)
+        cam1_yaml = next(iter([p for p in root.rglob("cam1/sensor.yaml") if p.is_file()]), None)
+        if cam0_yaml and cam1_yaml:
+            with open(cam0_yaml, "r", encoding="utf-8") as f:
+                c0 = yaml.safe_load(f) or {}
+            with open(cam1_yaml, "r", encoding="utf-8") as f:
+                c1 = yaml.safe_load(f) or {}
+            return FOURSEASONS_dataset._camera_from_sensor_yaml(c0), FOURSEASONS_dataset._camera_from_sensor_yaml(c1)
+
+        camchain = next(iter([p for p in root.rglob("*camchain*.yaml") if p.is_file()]), None)
+        if camchain:
+            with open(camchain, "r", encoding="utf-8") as f:
+                cc = yaml.safe_load(f) or {}
+            c0 = cc.get("cam0", {})
+            c1 = cc.get("cam1", {})
+            return FOURSEASONS_dataset._camera_from_camchain(c0), FOURSEASONS_dataset._camera_from_camchain(c1)
+
+        # Last-resort defaults for undistorted stereo pinhole.
+        dflt = {
+            "cam_model": "pinhole",
+            "focal_length": [320.0, 320.0],
+            "principal_point": [320.0, 240.0],
+            "T_BS": np.eye(4),
+        }
+        return dflt, dflt.copy()
+
+    @staticmethod
+    def _camera_from_sensor_yaml(cam: dict[str, Any]) -> dict[str, Any]:
+        intr = cam.get("intrinsics", [320.0, 320.0, 320.0, 240.0])
+        out: dict[str, Any] = {
+            "cam_model": "pinhole",
+            "focal_length": [float(intr[0]), float(intr[1])],
+            "principal_point": [float(intr[2]), float(intr[3])],
+            "T_BS": np.eye(4),
+        }
+        if "distortion_coefficients" in cam:
+            out["distortion_type"] = "radtan4"
+            out["distortion_coefficients"] = [float(x) for x in cam["distortion_coefficients"][:4]]
+        tbs = cam.get("T_BS", {}).get("data")
+        if tbs:
+            out["T_BS"] = np.array(tbs, dtype=float).reshape((4, 4))
+        return out
+
+    @staticmethod
+    def _camera_from_camchain(cam: dict[str, Any]) -> dict[str, Any]:
+        intr = cam.get("intrinsics", [320.0, 320.0, 320.0, 240.0])
+        out: dict[str, Any] = {
+            "cam_model": "pinhole",
+            "focal_length": [float(intr[0]), float(intr[1])],
+            "principal_point": [float(intr[2]), float(intr[3])],
+            "T_BS": np.array(cam.get("T_cam_imu", np.eye(4)), dtype=float),
+        }
+        dist = cam.get("distortion_coeffs")
+        if dist:
+            out["distortion_type"] = "equid4"
+            out["distortion_coefficients"] = [float(x) for x in dist[:4]]
+        return out

--- a/Datasets/dataset_files/dataset_4seasons.yaml
+++ b/Datasets/dataset_files/dataset_4seasons.yaml
@@ -1,0 +1,129 @@
+dataset_name: 4seasons
+
+rgb_hz: 20.0
+imu_hz: 200.0
+modes: ['stereo', 'stereo-vi', 'mono-vi']
+cam_models: ['pinhole', 'equid4']
+url_download_root: "https://vision.cs.tum.edu/webshare/g/4seasons-dataset/dataset"
+
+sequence_names:
+  - office_loop_1_train
+  - office_loop_2_train
+  - office_loop_3_train
+  - office_loop_4_train
+  - office_loop_5_train
+  - office_loop_6_train
+  - office_loop_2_test
+  - office_loop_3_test
+  - highway_1_test
+  - highway_2_test
+  - neighborhood_1_train
+  - neighborhood_2_train
+  - neighborhood_3_train
+  - neighborhood_4_train
+  - neighborhood_5_train
+  - neighborhood_6_train
+  - neighborhood_7_train
+  - neighborhood_2_test
+  - business_campus_1_train
+  - business_campus_2_train
+  - business_campus_3_train
+  - business_campus_1_test
+  - countryside_1_train
+  - countryside_2_train
+  - countryside_3_train
+  - countryside_4_train
+  - countryside_2_test
+  - city_loop_1_train
+  - city_loop_2_train
+  - city_loop_3_train
+  - city_loop_2_test
+  - old_town_1_train
+  - old_town_2_train
+  - old_town_3_train
+  - old_town_4_train
+  - old_town_2_test
+  - old_town_3_test
+  - maximilianeum_1_test
+  - maximilianeum_2_test
+  - parking_garage_1_train
+  - parking_garage_2_train
+  - parking_garage_3_train
+  - parking_garage_1_test
+
+with_reference_poses:
+  - office_loop_1_train
+  - office_loop_2_train
+  - office_loop_3_train
+  - office_loop_4_train
+  - office_loop_5_train
+  - office_loop_6_train
+  - neighborhood_1_train
+  - neighborhood_2_train
+  - neighborhood_3_train
+  - neighborhood_4_train
+  - neighborhood_5_train
+  - neighborhood_6_train
+  - neighborhood_7_train
+  - business_campus_1_train
+  - business_campus_2_train
+  - business_campus_3_train
+  - countryside_1_train
+  - countryside_2_train
+  - countryside_3_train
+  - countryside_4_train
+  - city_loop_1_train
+  - city_loop_2_train
+  - city_loop_3_train
+  - old_town_1_train
+  - old_town_2_train
+  - old_town_3_train
+  - old_town_4_train
+  - parking_garage_1_train
+  - parking_garage_2_train
+  - parking_garage_3_train
+
+recordings:
+  office_loop_1_train: recording_2020-03-24_17-36-22
+  office_loop_2_train: recording_2020-03-24_17-45-31
+  office_loop_3_train: recording_2020-04-07_10-20-32
+  office_loop_4_train: recording_2020-06-12_10-10-57
+  office_loop_5_train: recording_2021-01-07_12-04-03
+  office_loop_6_train: recording_2021-02-25_13-51-57
+  office_loop_2_test: recording_2020-03-26_15-03-02
+  office_loop_3_test: recording_2021-05-10_19-25-54
+  highway_1_test: recording_2020-10-08_10-19-46
+  highway_2_test: recording_2021-02-25_13-11-30
+  neighborhood_1_train: recording_2020-03-26_13-32-55
+  neighborhood_2_train: recording_2020-10-07_14-47-51
+  neighborhood_3_train: recording_2020-10-07_14-53-52
+  neighborhood_4_train: recording_2020-12-22_11-54-24
+  neighborhood_5_train: recording_2021-02-25_13-25-15
+  neighborhood_6_train: recording_2021-05-10_18-02-12
+  neighborhood_7_train: recording_2021-05-10_18-32-32
+  neighborhood_2_test: recording_2021-05-10_18-26-26
+  business_campus_1_train: recording_2020-10-08_09-30-57
+  business_campus_2_train: recording_2021-01-07_13-12-23
+  business_campus_3_train: recording_2021-02-25_14-16-43
+  business_campus_1_test: recording_2021-01-07_13-03-56
+  countryside_1_train: recording_2020-04-07_11-33-45
+  countryside_2_train: recording_2020-06-12_11-26-43
+  countryside_3_train: recording_2020-10-08_09-57-28
+  countryside_4_train: recording_2021-01-07_13-30-07
+  countryside_2_test: recording_2021-01-07_14-03-57
+  city_loop_1_train: recording_2020-12-22_11-33-15
+  city_loop_2_train: recording_2021-01-07_14-36-17
+  city_loop_3_train: recording_2021-02-25_11-09-49
+  city_loop_2_test: recording_2021-02-25_11-27-40
+  old_town_1_train: recording_2020-10-08_11-53-41
+  old_town_2_train: recording_2021-01-07_10-49-45
+  old_town_3_train: recording_2021-02-25_12-34-08
+  old_town_4_train: recording_2021-05-10_21-32-00
+  old_town_2_test: recording_2021-05-10_19-51-14
+  old_town_3_test: recording_2021-05-10_21-18-00
+  maximilianeum_1_test: recording_2021-02-25_12-16-32
+  maximilianeum_2_test: recording_2021-05-10_20-59-00
+  parking_garage_1_train: recording_2020-12-22_12-04-35
+  parking_garage_2_train: recording_2021-02-25_13-39-06
+  parking_garage_3_train: recording_2021-05-10_19-15-19
+  parking_garage_1_test: recording_2020-06-12_10-29-20

--- a/Datasets/dataset_files/dataset_7scenes.py
+++ b/Datasets/dataset_files/dataset_7scenes.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import csv
 import glob
-import yaml
 import shutil
 import numpy as np
 from pathlib import Path
@@ -24,18 +23,13 @@ class SEVENSCENES_dataset(DatasetVSLAMLab):
     def __init__(self, benchmark_path: str | Path, dataset_name: str = "7scenes") -> None:
         super().__init__(dataset_name, Path(benchmark_path))
 
-        # Load settings
-        with open(self.yaml_file, "r", encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-
-        # Get download url
-        self.url_download_root: str = cfg["url_download_root"]
+        self.url_download_root: str = self.cfg_require("url_download_root")
 
         # Sequence nicknames
         self.sequence_nicknames = [s.replace('_seq-', ' ') for s in self.sequence_names]
 
         # Depth factor
-        self.depth_factor = cfg["depth_factor"]
+        self.depth_factor = self.cfg_require("depth_factor")
         
     def download_sequence_data(self, sequence_name: str) -> None:
         sequence_group = _find_sequence_group(sequence_name)

--- a/Datasets/dataset_files/dataset_eth.py
+++ b/Datasets/dataset_files/dataset_eth.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import csv
-import yaml
 import numpy as np
 from pathlib import Path
 from urllib.parse import urljoin
@@ -21,12 +20,7 @@ class ETH_dataset(DatasetVSLAMLab):
     def __init__(self, benchmark_path: str | Path, dataset_name: str = "eth") -> None:
         super().__init__(dataset_name, Path(benchmark_path))
 
-        # Load settings
-        with open(self.yaml_file, "r", encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-
-        # Get download url
-        self.url_download_root: str = cfg["url_download_root"]
+        self.url_download_root: str = self.cfg_require("url_download_root")
 
         # Sequence nicknames
         self.sequence_nicknames = [s.replace("mannequin", "mann.")
@@ -37,7 +31,7 @@ class ETH_dataset(DatasetVSLAMLab):
                                    .replace("_", " ")[:MAX_NICKNAME_LEN] for s in self.sequence_names]
         
         # Depth factor
-        self.depth_factor = cfg["depth_factor"]
+        self.depth_factor = self.cfg_require("depth_factor")
 
     def download_sequence_data(self, sequence_name: str) -> None:
         for mode in self.modes:

--- a/Datasets/dataset_files/dataset_kitti.py
+++ b/Datasets/dataset_files/dataset_kitti.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import os
 import csv
-import yaml
 import shutil
 import numpy as np
 from typing import  Any
@@ -22,13 +21,8 @@ class KITTI_dataset(DatasetVSLAMLab):
     def __init__(self, benchmark_path: str | Path, dataset_name: str = "kitti") -> None:
         super().__init__(dataset_name, Path(benchmark_path))
 
-        # Load settings
-        with open(self.yaml_file, "r", encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-
-        # Get download url
-        self.url_download_root: str = cfg["url_download_root"]
-        self.url_download_root_gt: str = cfg["url_download_root_gt"]
+        self.url_download_root: str = self.cfg_require("url_download_root")
+        self.url_download_root_gt: str = self.cfg_require("url_download_root_gt")
 
         # Sequence nicknames
         self.sequence_nicknames = self.sequence_names

--- a/Datasets/dataset_files/dataset_monotum.py
+++ b/Datasets/dataset_files/dataset_monotum.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import csv
+import os
+import shutil
+import subprocess
+from contextlib import suppress
+from pathlib import Path
+from urllib.parse import urljoin
+from zipfile import ZipFile
+from typing import Any
+
+import numpy as np
+import yaml
+
+from Datasets.DatasetVSLAMLab import DatasetVSLAMLab
+from path_constants import BENCHMARK_RETENTION, Retention, VSLAM_LAB_DIR
+from utilities import downloadFile, decompressFile, replace_string_in_files
+
+
+class MONOTUM_dataset(DatasetVSLAMLab):
+    """Monocular TUM dataset helper for VSLAM-LAB benchmark."""
+
+    def __init__(self, benchmark_path: str | Path, dataset_name: str = "monotum") -> None:
+        super().__init__(dataset_name, Path(benchmark_path))
+
+        with open(self.yaml_file, "r", encoding="utf-8") as f:
+            cfg = yaml.safe_load(f) or {}
+
+        self.url_download_root: str = cfg["url_download_root"]
+        self.sequence_nicknames = [s.replace("sequence_", "seq ") for s in self.sequence_names]
+        self.mono_dataset_code_dir = VSLAM_LAB_DIR / "Baselines" / "mono_dataset_code"
+
+    def download_sequence_data(self, sequence_name: str) -> None:
+        compressed_name_ext = f"{sequence_name}.zip"
+        download_url = urljoin(self.url_download_root.rstrip("/") + "/", compressed_name_ext)
+
+        compressed_file = self.dataset_path / compressed_name_ext
+        sequence_path = self.dataset_path / sequence_name
+
+        if not compressed_file.exists():
+            downloadFile(download_url, str(self.dataset_path))
+
+        if not sequence_path.exists():
+            decompressFile(str(compressed_file), str(self.dataset_path))
+
+    def create_rgb_folder(self, sequence_name: str) -> None:
+        sequence_path = self.dataset_path / sequence_name
+        rgb_path = sequence_path / "rgb_0"
+        rgb_path.mkdir(parents=True, exist_ok=True)
+
+        images_zip = sequence_path / "images.zip"
+        if not images_zip.exists():
+            return
+
+        if self._run_official_undistort(sequence_path):
+            return
+
+        # Fallback: extract image files directly when undistorter is unavailable.
+        with ZipFile(images_zip, "r") as zf:
+            image_members = [m for m in zf.namelist()
+                             if m.lower().endswith((".jpg", ".jpeg", ".png"))
+                             and not m.endswith("/")]
+            image_members.sort()
+            for i, member in enumerate(image_members):
+                ext = Path(member).suffix.lower() or ".jpg"
+                out_name = f"{i:05d}{ext}"
+                with zf.open(member) as src, open(rgb_path / out_name, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+
+    def create_rgb_csv(self, sequence_name: str) -> None:
+        sequence_path = self.dataset_path / sequence_name
+        rgb_path = sequence_path / "rgb_0"
+        times_txt = sequence_path / "times.txt"
+        rgb_csv = sequence_path / "rgb.csv"
+
+        timestamps = self._read_timestamps(times_txt)
+        rgb_files = sorted([f for f in os.listdir(rgb_path) if (rgb_path / f).is_file()])
+
+        n = min(len(rgb_files), len(timestamps))
+        with open(rgb_csv, "w", newline="", encoding="utf-8") as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(["ts_rgb_0 (ns)", "path_rgb_0"])
+            for i in range(n):
+                ts_ns = int(float(timestamps[i]) * 1e9)
+                writer.writerow([ts_ns, f"rgb_0/{rgb_files[i]}"])
+
+    def create_calibration_yaml(self, sequence_name: str) -> None:
+        sequence_path = self.dataset_path / sequence_name
+        calibration_txt = sequence_path / "calibration.txt"
+        camera_txt = sequence_path / "camera.txt"
+
+        fx = fy = cx = cy = None
+        if calibration_txt.exists():
+            with open(calibration_txt, "r", encoding="utf-8") as f:
+                vals = f.readline().split()
+                if len(vals) >= 4:
+                    fx, fy, cx, cy = map(float, vals[:4])
+        elif camera_txt.exists():
+            with open(camera_txt, "r", encoding="utf-8") as f:
+                vals = f.readline().split()
+                if len(vals) >= 4:
+                    fx, fy, cx, cy = map(float, vals[:4])
+
+        if None in (fx, fy, cx, cy):
+            raise ValueError(f"Could not read intrinsics for sequence '{sequence_name}'")
+
+        rgb0: dict[str, Any] = {
+            "cam_name": "rgb_0",
+            "cam_type": "gray",
+            "cam_model": "pinhole",
+            "focal_length": [fx, fy],
+            "principal_point": [cx, cy],
+            "fps": float(self.rgb_hz),
+            "T_BS": np.eye(4),
+        }
+        self.write_calibration_yaml(sequence_name=sequence_name, rgb=[rgb0])
+
+    def create_groundtruth_csv(self, sequence_name: str) -> None:
+        sequence_path = self.dataset_path / sequence_name
+        src = sequence_path / "groundtruthSync.txt"
+        dst = sequence_path / "groundtruth.csv"
+
+        if not src.exists():
+            return
+
+        tmp = dst.with_suffix(".csv.tmp")
+        with open(src, "r", encoding="utf-8") as fin, open(tmp, "w", newline="", encoding="utf-8") as fout:
+            w = csv.writer(fout)
+            w.writerow(["ts (ns)", "tx (m)", "ty (m)", "tz (m)", "qx", "qy", "qz", "qw"])
+            for line in fin:
+                s = line.strip()
+                if not s or "NaN" in s:
+                    continue
+                parts = s.split()
+                if len(parts) < 8:
+                    continue
+                ts_ns = int(float(parts[0]) * 1e9)
+                w.writerow([ts_ns] + parts[1:8])
+        tmp.replace(dst)
+        with suppress(FileNotFoundError):
+            tmp.unlink()
+
+    def remove_unused_files(self, sequence_name: str) -> None:
+        sequence_path = self.dataset_path / sequence_name
+        if BENCHMARK_RETENTION != Retention.FULL:
+            for name in ("groundtruthSync.txt", "times.txt", "pcalib.txt", "statistics.txt", "vignette.png"):
+                (sequence_path / name).unlink(missing_ok=True)
+
+        if BENCHMARK_RETENTION == Retention.MINIMAL:
+            (self.dataset_path / f"{sequence_name}.zip").unlink(missing_ok=True)
+
+    @staticmethod
+    def _read_timestamps(times_txt: Path) -> list[float]:
+        if not times_txt.exists():
+            raise FileNotFoundError(f"Missing file: {times_txt}")
+
+        out: list[float] = []
+        with open(times_txt, "r", encoding="utf-8") as f:
+            for line in f:
+                cols = line.split()
+                if not cols:
+                    continue
+                ts = cols[1] if len(cols) > 1 else cols[0]
+                out.append(float(ts))
+        return out
+
+    def _run_official_undistort(self, sequence_path: Path) -> bool:
+        bin_file = self.mono_dataset_code_dir / "bin" / "playbackDataset"
+        if not bin_file.exists() and not self._build_mono_dataset_code():
+            return False
+
+        rgb_dir = sequence_path / "rgb"
+        rgb_dir.mkdir(parents=True, exist_ok=True)
+        cmd = [str(bin_file), str(sequence_path), str(sequence_path)]
+        try:
+            subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        except Exception:
+            return False
+
+        if not rgb_dir.exists():
+            return False
+
+        target = sequence_path / "rgb_0"
+        for img in sorted(rgb_dir.glob("*")):
+            if img.is_file():
+                img.rename(target / img.name)
+        shutil.rmtree(rgb_dir, ignore_errors=True)
+        return True
+
+    def _build_mono_dataset_code(self) -> bool:
+        if (self.mono_dataset_code_dir / "bin" / "playbackDataset").exists():
+            return True
+
+        if not self.mono_dataset_code_dir.exists():
+            try:
+                subprocess.run(
+                    ["git", "clone", "https://github.com/tum-vision/mono_dataset_code.git", str(self.mono_dataset_code_dir)],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+            except Exception:
+                return False
+
+        replace_string_in_files(str(self.mono_dataset_code_dir), "CV_LOAD_IMAGE_UNCHANGED", "cv::IMREAD_UNCHANGED")
+        replace_string_in_files(str(self.mono_dataset_code_dir), "CV_LOAD_IMAGE_GRAYSCALE", "cv::IMREAD_GRAYSCALE")
+
+        extra_dir = VSLAM_LAB_DIR / "Datasets" / "extra-files"
+        with suppress(Exception):
+            shutil.copy(extra_dir / "CMakeLists.txt", self.mono_dataset_code_dir / "CMakeLists.txt")
+            shutil.copy(extra_dir / "main_playbackDataset.cpp", self.mono_dataset_code_dir / "src" / "main_playbackDataset.cpp")
+            shutil.copy(extra_dir / "build.sh", self.mono_dataset_code_dir / "build.sh")
+
+        try:
+            subprocess.run(
+                ["bash", str(self.mono_dataset_code_dir / "build.sh")],
+                cwd=str(self.mono_dataset_code_dir),
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except Exception:
+            return False
+
+        return (self.mono_dataset_code_dir / "bin" / "playbackDataset").exists()

--- a/Datasets/dataset_files/dataset_monotum.py
+++ b/Datasets/dataset_files/dataset_monotum.py
@@ -11,7 +11,6 @@ from zipfile import ZipFile
 from typing import Any
 
 import numpy as np
-import yaml
 
 from Datasets.DatasetVSLAMLab import DatasetVSLAMLab
 from path_constants import BENCHMARK_RETENTION, Retention, VSLAM_LAB_DIR
@@ -24,10 +23,7 @@ class MONOTUM_dataset(DatasetVSLAMLab):
     def __init__(self, benchmark_path: str | Path, dataset_name: str = "monotum") -> None:
         super().__init__(dataset_name, Path(benchmark_path))
 
-        with open(self.yaml_file, "r", encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-
-        self.url_download_root: str = cfg["url_download_root"]
+        self.url_download_root: str = self.cfg_require("url_download_root")
         self.sequence_nicknames = [s.replace("sequence_", "seq ") for s in self.sequence_names]
         self.mono_dataset_code_dir = VSLAM_LAB_DIR / "Baselines" / "mono_dataset_code"
 

--- a/Datasets/dataset_files/dataset_monotum.yaml
+++ b/Datasets/dataset_files/dataset_monotum.yaml
@@ -1,0 +1,58 @@
+dataset_name: monotum
+
+rgb_hz: 40.0
+modes: ['mono']
+cam_models: ['pinhole']
+url_download_root: "https://cvg.cit.tum.de/mono/dataset"
+
+sequence_names:
+  - sequence_01
+  - sequence_02
+  - sequence_03
+  - sequence_04
+  - sequence_05
+  - sequence_06
+  - sequence_07
+  - sequence_08
+  - sequence_09
+  - sequence_10
+  - sequence_11
+  - sequence_12
+  - sequence_13
+  - sequence_14
+  - sequence_15
+  - sequence_16
+  - sequence_17
+  - sequence_18
+  - sequence_19
+  - sequence_20
+  - sequence_21
+  - sequence_22
+  - sequence_23
+  - sequence_24
+  - sequence_25
+  - sequence_26
+  - sequence_27
+  - sequence_28
+  - sequence_29
+  - sequence_30
+  - sequence_31
+  - sequence_32
+  - sequence_33
+  - sequence_34
+  - sequence_35
+  - sequence_36
+  - sequence_37
+  - sequence_38
+  - sequence_39
+  - sequence_40
+  - sequence_41
+  - sequence_42
+  - sequence_43
+  - sequence_44
+  - sequence_45
+  - sequence_46
+  - sequence_47
+  - sequence_48
+  - sequence_49
+  - sequence_50

--- a/Datasets/dataset_files/dataset_nuim.py
+++ b/Datasets/dataset_files/dataset_nuim.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import csv
-import yaml
 import numpy as np
 from pathlib import Path
 from typing import Final, Any
@@ -20,19 +19,14 @@ class NUIM_dataset(DatasetVSLAMLab):
     def __init__(self, benchmark_path: str | Path, dataset_name: str = "nuim") -> None:
         super().__init__(dataset_name, Path(benchmark_path))
 
-        # Load settings
-        with open(self.yaml_file, "r", encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-
-        # Get download url
-        self.url_download_root: str = cfg["url_download_root"]
+        self.url_download_root: str = self.cfg_require("url_download_root")
 
         # Sequence nicknames
         self.sequence_nicknames = [s.replace('_frei_png', '') for s in self.sequence_names]
         self.sequence_nicknames = [s.replace('_', ' ') for s in self.sequence_nicknames]
 
         # Depth factor
-        self.depth_factor = cfg["depth_factor"]
+        self.depth_factor = self.cfg_require("depth_factor")
 
     def download_sequence_data(self, sequence_name: str) -> None:
         sequence_path = self.dataset_path / sequence_name

--- a/Datasets/dataset_files/dataset_replica.py
+++ b/Datasets/dataset_files/dataset_replica.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import csv
-import yaml
 import os, shutil 
 import numpy as np
 from pathlib import Path
@@ -22,18 +21,13 @@ class REPLICA_dataset(DatasetVSLAMLab):
     def __init__(self, benchmark_path: str | Path, dataset_name: str = "replica") -> None:
         super().__init__(dataset_name, Path(benchmark_path))
 
-        # Load settings
-        with open(self.yaml_file, "r", encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-
-        # Get download url
-        self.url_download_root: str = cfg["url_download_root"]
+        self.url_download_root: str = self.cfg_require("url_download_root")
 
         # Sequence nicknames
         self.sequence_nicknames = [s.replace('_', ' ') for s in self.sequence_names]
 
         # Depth factor
-        self.depth_factor = cfg["depth_factor"]
+        self.depth_factor = self.cfg_require("depth_factor")
 
     def download_sequence_data(self, sequence_name: str) -> None:
 

--- a/Datasets/dataset_files/dataset_rgbdtum.py
+++ b/Datasets/dataset_files/dataset_rgbdtum.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import yaml
 import numpy as np
 import pandas as pd
 from pathlib import Path
@@ -27,18 +26,13 @@ class RGBDTUM_dataset(DatasetVSLAMLab):
     def __init__(self, benchmark_path: str | Path, dataset_name: str = "rgbdtum") -> None:
         super().__init__(dataset_name, Path(benchmark_path))
 
-        # Load settings
-        with open(self.yaml_file, "r", encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-
-        # Get download url
-        self.url_download_root: str = cfg["url_download_root"]
+        self.url_download_root: str = self.cfg_require("url_download_root")
 
         # Sequence nicknames
         self.sequence_nicknames = [self._nickname(s) for s in self.sequence_names]
 
         # Depth factor
-        self.depth_factor = cfg["depth_factor"]
+        self.depth_factor = self.cfg_require("depth_factor")
 
     def download_sequence_data(self, sequence_name: str) -> None:
         sequence_path = self.dataset_path / sequence_name

--- a/Datasets/dataset_files/dataset_squidle.py
+++ b/Datasets/dataset_files/dataset_squidle.py
@@ -4,7 +4,6 @@ import os
 import csv
 import utm
 import math 
-import yaml
 import json
 import shutil
 import pandas as pd
@@ -39,13 +38,8 @@ class SQUIDLE_dataset(DatasetVSLAMLab):
     def __init__(self, benchmark_path: str | Path, dataset_name: str = "squidle") -> None:
         super().__init__(dataset_name, Path(benchmark_path))
 
-        # Load settings
-        with open(self.yaml_file, "r", encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-
-        # Get download url
-        self.url_download_root: str = cfg["url_download_root"]
-        self.api_token: str = cfg.get("api_token", "not_set") 
+        self.url_download_root: str = self.cfg_require("url_download_root")
+        self.api_token: str = self.cfg_get("api_token", "not_set")
         if len(self.api_token.strip()) == 0:
             self.api_token = "not_set"
         if self.api_token == "not_set":
@@ -56,7 +50,7 @@ class SQUIDLE_dataset(DatasetVSLAMLab):
         self.sequence_nicknames = self.sequence_names
 
         # Target image resolution
-        self.image_resolution = cfg.get("target_resolution", [640, 480])
+        self.image_resolution = self.cfg_get("target_resolution", [640, 480])
     
     def download_sequence_data(self, sequence_name: str) -> None:
         sequence_path: Path = self.dataset_path / sequence_name
@@ -224,12 +218,8 @@ class SESOKO_dataset(SQUIDLE_dataset):
     def __init__(self, benchmark_path: str | Path, dataset_name: str = "sesoko") -> None:
         super().__init__(Path(benchmark_path), dataset_name) 
 
-        # Load settings
-        with open(self.yaml_file, "r", encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-
-        self.subsets = cfg.get("subsets", {})
-        self.combined = cfg.get("combined", {})
+        self.subsets = self.cfg_get("subsets", {})
+        self.combined = self.cfg_get("combined", {})
 
     def download_sequence_data(self, sequence_name: str) -> None:
         sequence_path: Path = self.dataset_path / sequence_name
@@ -374,4 +364,3 @@ def _parse_pose_data(item, origin_utm, origin_zone):
     ty = northing - origin_utm[1]
     tz = item.get('dep')
     return [ts_ns, tx, ty, tz, qx, qy, qz, qw]
-

--- a/Datasets/dataset_files/dataset_squidle.py
+++ b/Datasets/dataset_files/dataset_squidle.py
@@ -35,7 +35,7 @@ IMAGE_CROP: Final = {"ssk16": [146,3], "ssk17": [6,13], "ssk18": [4,6]}
 class SQUIDLE_dataset(DatasetVSLAMLab):
     """SQUIDLE dataset helper for VSLAM-LAB benchmark."""
 
-    def __init__(self, benchmark_path: str | Path, dataset_name: str = "sesoko") -> None:
+    def __init__(self, benchmark_path: str | Path, dataset_name: str = "squidle") -> None:
         super().__init__(dataset_name, Path(benchmark_path))
 
         self.url_download_root: str = self.cfg_require("url_download_root")

--- a/Datasets/dataset_files/dataset_squidle.py
+++ b/Datasets/dataset_files/dataset_squidle.py
@@ -35,7 +35,7 @@ IMAGE_CROP: Final = {"ssk16": [146,3], "ssk17": [6,13], "ssk18": [4,6]}
 class SQUIDLE_dataset(DatasetVSLAMLab):
     """SQUIDLE dataset helper for VSLAM-LAB benchmark."""
 
-    def __init__(self, benchmark_path: str | Path, dataset_name: str = "squidle") -> None:
+    def __init__(self, benchmark_path: str | Path, dataset_name: str = "sesoko") -> None:
         super().__init__(dataset_name, Path(benchmark_path))
 
         self.url_download_root: str = self.cfg_require("url_download_root")

--- a/Datasets/dataset_files/dataset_tartanair.py
+++ b/Datasets/dataset_files/dataset_tartanair.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import os
 import csv
-import yaml
 import shutil
 import numpy as np
 from pathlib import Path
@@ -24,13 +23,8 @@ class TARTANAIR_dataset(DatasetVSLAMLab):
     def __init__(self, benchmark_path: str | Path, dataset_name: str = "tartanair") -> None:
         super().__init__(dataset_name, Path(benchmark_path))
 
-        # Load settings
-        with open(self.yaml_file, "r", encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-
-        # Get download url
-        self.url_download_root: str = cfg["url_download_root"]
-        self.url_download_gt_root: str = cfg["url_download_gt_root"]
+        self.url_download_root: str = self.cfg_require("url_download_root")
+        self.url_download_gt_root: str = self.cfg_require("url_download_gt_root")
 
         # Sequence nicknames
         self.sequence_nicknames = self.sequence_names

--- a/Datasets/dataset_files/dataset_vitum.py
+++ b/Datasets/dataset_files/dataset_vitum.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import csv
+import re
+import shutil
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin
+
+import numpy as np
+import pandas as pd
+import yaml
+
+from Datasets.DatasetVSLAMLab import DatasetVSLAMLab
+from path_constants import BENCHMARK_RETENTION, Retention
+from utilities import decompressFile, downloadFile
+
+
+class VITUM_dataset(DatasetVSLAMLab):
+    """TUM VI dataset helper for VSLAM-LAB benchmark."""
+
+    def __init__(self, benchmark_path: str | Path, dataset_name: str = "vitum") -> None:
+        super().__init__(dataset_name, Path(benchmark_path))
+
+        self.url_download_root: str = self.cfg_require("url_download_root")
+        self.imu_hz: float = float(self.cfg_get("imu_hz", 200.0))
+        self.sequence_nicknames = self.sequence_names
+
+    def download_sequence_data(self, sequence_name: str) -> None:
+        archive_name = f"dataset-{sequence_name}_512_16.tar"
+        archive_url = urljoin(self.url_download_root.rstrip("/") + "/", archive_name)
+
+        archive_path = self.dataset_path / archive_name
+        extracted_root = self._source_root(sequence_name)
+
+        if not archive_path.exists():
+            downloadFile(archive_url, str(self.dataset_path))
+
+        if not extracted_root.exists():
+            decompressFile(str(archive_path), str(self.dataset_path))
+
+    def create_rgb_folder(self, sequence_name: str) -> None:
+        sequence_path = self.dataset_path / sequence_name
+        rgb_path = sequence_path / "rgb_0"
+        if rgb_path.exists():
+            return
+
+        src_dir = self._source_root(sequence_name) / "mav0" / "cam0" / "data"
+        if not src_dir.exists():
+            raise FileNotFoundError(f"Missing cam0 data folder: {src_dir}")
+
+        rgb_path.mkdir(parents=True, exist_ok=True)
+        for img in sorted(src_dir.glob("*.png")):
+            shutil.copy2(img, rgb_path / img.name)
+
+    def create_rgb_csv(self, sequence_name: str) -> None:
+        sequence_path = self.dataset_path / sequence_name
+        rgb_path = sequence_path / "rgb_0"
+        rgb_csv = sequence_path / "rgb.csv"
+        if rgb_csv.exists():
+            return
+
+        ts_by_stem = self._load_times_map(sequence_name)
+        rgb_files = sorted([p.name for p in rgb_path.iterdir() if p.is_file() and p.suffix.lower() == ".png"])
+
+        tmp = rgb_csv.with_suffix(".csv.tmp")
+        with open(tmp, "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(["ts_rgb_0 (ns)", "path_rgb_0"])
+            for filename in rgb_files:
+                stem = Path(filename).stem
+                if stem in ts_by_stem:
+                    ts_ns = int(ts_by_stem[stem])
+                else:
+                    # Fallback: filenames are usually nanosecond timestamps.
+                    ts_ns = int(stem)
+                w.writerow([ts_ns, f"rgb_0/{filename}"])
+        tmp.replace(rgb_csv)
+
+    def create_imu_csv(self, sequence_name: str) -> None:
+        src = self._source_root(sequence_name) / "mav0" / "imu0" / "data.csv"
+        dst = self.dataset_path / sequence_name / "imu_0.csv"
+        if not src.exists():
+            return
+        if dst.exists() and dst.stat().st_mtime >= src.stat().st_mtime:
+            return
+
+        cols = [
+            "timestamp [ns]",
+            "w_RS_S_x [rad s^-1]",
+            "w_RS_S_y [rad s^-1]",
+            "w_RS_S_z [rad s^-1]",
+            "a_RS_S_x [m s^-2]",
+            "a_RS_S_y [m s^-2]",
+            "a_RS_S_z [m s^-2]",
+        ]
+        df = pd.read_csv(src, comment="#", header=None, names=cols, sep=r"[\s,]+", engine="python")
+        if df.empty:
+            return
+
+        out = pd.DataFrame(
+            {
+                "ts (ns)": df["timestamp [ns]"].astype(np.int64),
+                "wx (rad s^-1)": df["w_RS_S_x [rad s^-1]"],
+                "wy (rad s^-1)": df["w_RS_S_y [rad s^-1]"],
+                "wz (rad s^-1)": df["w_RS_S_z [rad s^-1]"],
+                "ax (m s^-2)": df["a_RS_S_x [m s^-2]"],
+                "ay (m s^-2)": df["a_RS_S_y [m s^-2]"],
+                "az (m s^-2)": df["a_RS_S_z [m s^-2]"],
+            }
+        )
+
+        tmp = dst.with_suffix(".csv.tmp")
+        out.to_csv(tmp, index=False)
+        tmp.replace(dst)
+
+    def create_calibration_yaml(self, sequence_name: str) -> None:
+        src_root = self._source_root(sequence_name)
+
+        camchain = src_root / "dso" / "camchain.yaml"
+        imu_cfg = src_root / "dso" / "imu_config.yaml"
+        cam_sensor = src_root / "mav0" / "cam0" / "sensor.yaml"
+
+        intrinsics = [190.97847715128717, 190.9733070521226, 254.93170605935475, 256.8974428996504]
+        distortion = [0.0034823894022493434, 0.0007150348452162257, -0.0020532361418706202, 0.00020293673591811182]
+        T_cam_imu = np.eye(4)
+
+        if camchain.exists():
+            with open(camchain, "r", encoding="utf-8") as f:
+                cam_data = yaml.safe_load(f) or {}
+            cam0 = cam_data.get("cam0", {})
+            intrinsics = cam0.get("intrinsics", intrinsics)
+            distortion = cam0.get("distortion_coeffs", distortion)
+            T_cam_imu = np.array(cam0.get("T_cam_imu", np.eye(4)), dtype=float)
+        elif cam_sensor.exists():
+            with open(cam_sensor, "r", encoding="utf-8") as f:
+                cam_data = yaml.safe_load(f) or {}
+            intrinsics = cam_data.get("intrinsics", intrinsics)
+            distortion = cam_data.get("distortion_coefficients", distortion)
+            T_raw = cam_data.get("T_BS", {}).get("data")
+            if T_raw:
+                T_cam_imu = np.array(T_raw, dtype=float).reshape((4, 4))
+
+        imu_noise = {
+            "gyro_noise_density": 1.7e-4,
+            "gyroscope_random_walk": 1.9393e-5,
+            "accelerometer_noise_density": 2.0e-3,
+            "accelerometer_random_walk": 3.0e-3,
+            "update_rate": self.imu_hz,
+        }
+        if imu_cfg.exists():
+            with open(imu_cfg, "r", encoding="utf-8") as f:
+                loaded = yaml.safe_load(f) or {}
+            imu_noise.update(loaded)
+
+        fx, fy, cx, cy = [float(x) for x in intrinsics[:4]]
+        rgb0: dict[str, Any] = {
+            "cam_name": "rgb_0",
+            "cam_type": "gray",
+            "cam_model": "equid4",
+            "focal_length": [fx, fy],
+            "principal_point": [cx, cy],
+            "distortion_type": "equid4",
+            "distortion_coefficients": [float(x) for x in distortion[:4]],
+            "fps": float(self.rgb_hz),
+            "T_BS": T_cam_imu,
+        }
+
+        imu0: dict[str, Any] = {
+            "imu_name": "imu_0",
+            "a_max": 176.0,
+            "g_max": 7.8,
+            "sigma_g_c": float(imu_noise["gyro_noise_density"]),
+            "sigma_a_c": float(imu_noise["accelerometer_noise_density"]),
+            "sigma_bg": float(imu_noise["gyroscope_random_walk"]),
+            "sigma_ba": float(imu_noise["accelerometer_random_walk"]),
+            "sigma_gw_c": float(imu_noise["gyroscope_random_walk"]),
+            "sigma_aw_c": float(imu_noise["accelerometer_random_walk"]),
+            "g": 9.81007,
+            "g0": [0.0, 0.0, 0.0],
+            "a0": [0.0, 0.0, 0.0],
+            "s_a": [1.0, 1.0, 1.0],
+            "fps": float(imu_noise.get("update_rate", self.imu_hz)),
+            "T_BS": np.eye(4),
+        }
+
+        self.write_calibration_yaml(sequence_name=sequence_name, rgb=[rgb0], imu=[imu0])
+
+    def create_groundtruth_csv(self, sequence_name: str) -> None:
+        src = self._source_root(sequence_name) / "dso" / "gt_imu.csv"
+        dst = self.dataset_path / sequence_name / "groundtruth.csv"
+        if not src.exists():
+            return
+
+        tmp = dst.with_suffix(".csv.tmp")
+        with open(src, "r", encoding="utf-8") as fin, open(tmp, "w", newline="", encoding="utf-8") as fout:
+            w = csv.writer(fout)
+            w.writerow(["ts (ns)", "tx (m)", "ty (m)", "tz (m)", "qx", "qy", "qz", "qw"])
+
+            for line in fin:
+                s = line.strip()
+                if not s or s.startswith("#"):
+                    continue
+                parts = [p for p in re.split(r"[\s,]+", s) if p]
+                if len(parts) < 8:
+                    continue
+                try:
+                    vals = [float(v) for v in parts[:8]]
+                except ValueError:
+                    continue
+                if any(np.isnan(v) for v in vals):
+                    continue
+
+                ts = vals[0]
+                ts_ns = int(ts * 1e9) if ts < 1e12 else int(ts)
+                tx, ty, tz = vals[1], vals[2], vals[3]
+                qw, qx, qy, qz = vals[4], vals[5], vals[6], vals[7]
+                w.writerow([ts_ns, tx, ty, tz, qx, qy, qz, qw])
+
+        tmp.replace(dst)
+
+    def remove_unused_files(self, sequence_name: str) -> None:
+        source_root = self._source_root(sequence_name)
+        if BENCHMARK_RETENTION != Retention.FULL:
+            shutil.rmtree(source_root, ignore_errors=True)
+
+        if BENCHMARK_RETENTION == Retention.MINIMAL:
+            archive = self.dataset_path / f"dataset-{sequence_name}_512_16.tar"
+            archive.unlink(missing_ok=True)
+
+    def _source_root(self, sequence_name: str) -> Path:
+        return self.dataset_path / f"dataset-{sequence_name}_512_16"
+
+    def _load_times_map(self, sequence_name: str) -> dict[str, int]:
+        times_file = self._source_root(sequence_name) / "dso" / "cam0" / "times.txt"
+        out: dict[str, int] = {}
+        if not times_file.exists():
+            return out
+
+        with open(times_file, "r", encoding="utf-8") as f:
+            for line in f:
+                s = line.strip()
+                if not s or s.startswith("#"):
+                    continue
+                cols = s.split()
+                if len(cols) < 2:
+                    continue
+                stem = cols[0].split(".")[0]
+                try:
+                    ts_ns = int(float(cols[1]) * 1e9)
+                except ValueError:
+                    continue
+                out[stem] = ts_ns
+        return out

--- a/Datasets/dataset_files/dataset_vitum.yaml
+++ b/Datasets/dataset_files/dataset_vitum.yaml
@@ -1,0 +1,37 @@
+dataset_name: vitum
+
+rgb_hz: 20.0
+imu_hz: 200.0
+modes: ['mono', 'mono-vi']
+cam_models: ['equid4']
+url_download_root: "https://vision.in.tum.de/tumvi/exported/euroc/512_16/"
+
+sequence_names:
+  - corridor1
+  - corridor2
+  - corridor3
+  - corridor4
+  - corridor5
+  - magistrale1
+  - magistrale2
+  - magistrale3
+  - magistrale4
+  - magistrale5
+  - magistrale6
+  - outdoors1
+  - outdoors2
+  - outdoors3
+  - outdoors4
+  - outdoors5
+  - outdoors6
+  - outdoors7
+  - outdoors8
+  - room1
+  - room2
+  - room3
+  - room4
+  - room5
+  - room6
+  - slides1
+  - slides2
+  - slides3

--- a/Datasets/get_dataset.py
+++ b/Datasets/get_dataset.py
@@ -9,6 +9,7 @@ from Datasets.dataset_files.dataset_tartanair import TARTANAIR_dataset
 from Datasets.dataset_files.dataset_squidle import SESOKO_dataset   
 from Datasets.dataset_files.dataset_monotum import MONOTUM_dataset
 from Datasets.dataset_files.dataset_vitum import VITUM_dataset
+from Datasets.dataset_files.dataset_4seasons import FOURSEASONS_dataset
 
 # RGBD datasets
 from Datasets.dataset_files.dataset_eth import ETH_dataset
@@ -71,6 +72,7 @@ def get_dataset(dataset_name, benchmark_path):
         "sesoko": lambda: SESOKO_dataset(benchmark_path),
         "squidle": lambda: SESOKO_dataset(benchmark_path),
         "vitum": lambda: VITUM_dataset(benchmark_path),
+        "4seasons": lambda: FOURSEASONS_dataset(benchmark_path),
         "7scenes": lambda: SEVENSCENES_dataset(benchmark_path),
         "openloris-d400": lambda: OPENLORIS_d400_dataset(benchmark_path),
         "openloris-t265": lambda: OPENLORIS_t265_dataset(benchmark_path),

--- a/Datasets/get_dataset.py
+++ b/Datasets/get_dataset.py
@@ -7,6 +7,7 @@ from path_constants import VSLAM_LAB_DIR
 # Monocular datasets
 from Datasets.dataset_files.dataset_tartanair import TARTANAIR_dataset
 from Datasets.dataset_files.dataset_squidle import SESOKO_dataset   
+from Datasets.dataset_files.dataset_monotum import MONOTUM_dataset
 
 # RGBD datasets
 from Datasets.dataset_files.dataset_eth import ETH_dataset
@@ -34,7 +35,6 @@ from Datasets.dataset_vitum import VITUM_dataset
 from Datasets.dataset_scannetplusplus import SCANNETPLUSPLUS_dataset
 from Datasets.dataset_lizardisland import LIZARDISLAND_dataset
 from Datasets.dataset_ariel import ARIEL_dataset
-from Datasets.dataset_monotum import MONOTUM_dataset
 from Datasets.dataset_drunkards import DRUNKARDS_dataset
 from Datasets.dataset_hamlyn import HAMLYN_dataset
 from Datasets.dataset_caves import CAVES_dataset
@@ -72,6 +72,7 @@ def get_dataset(dataset_name, benchmark_path):
         "7scenes": lambda: SEVENSCENES_dataset(benchmark_path),
         "openloris-d400": lambda: OPENLORIS_d400_dataset(benchmark_path),
         "openloris-t265": lambda: OPENLORIS_t265_dataset(benchmark_path),
+        "monotum": lambda: MONOTUM_dataset(benchmark_path),
 
         # Development
         "vitum": lambda: VITUM_dataset(benchmark_path),
@@ -80,7 +81,6 @@ def get_dataset(dataset_name, benchmark_path):
         "hamlyn": lambda: HAMLYN_dataset(benchmark_path),
         "drunkards": lambda: DRUNKARDS_dataset(benchmark_path),
         "ariel": lambda: ARIEL_dataset(benchmark_path),
-        "monotum": lambda: MONOTUM_dataset(benchmark_path),
         "caves": lambda: CAVES_dataset(benchmark_path),
         "lamar": lambda: LAMAR_dataset(benchmark_path),
         "eth3d_mvs_dslr": lambda: ETH3D_MVS_DSLR_dataset(benchmark_path),

--- a/Datasets/get_dataset.py
+++ b/Datasets/get_dataset.py
@@ -8,6 +8,7 @@ from path_constants import VSLAM_LAB_DIR
 from Datasets.dataset_files.dataset_tartanair import TARTANAIR_dataset
 from Datasets.dataset_files.dataset_squidle import SESOKO_dataset   
 from Datasets.dataset_files.dataset_monotum import MONOTUM_dataset
+from Datasets.dataset_files.dataset_vitum import VITUM_dataset
 
 # RGBD datasets
 from Datasets.dataset_files.dataset_eth import ETH_dataset
@@ -31,7 +32,6 @@ from Datasets.dataset_files.dataset_openloris import OPENLORIS_d400_dataset
 from Datasets.dataset_files.dataset_openloris import OPENLORIS_t265_dataset
 
 # Development
-from Datasets.dataset_vitum import VITUM_dataset
 from Datasets.dataset_scannetplusplus import SCANNETPLUSPLUS_dataset
 from Datasets.dataset_lizardisland import LIZARDISLAND_dataset
 from Datasets.dataset_ariel import ARIEL_dataset
@@ -70,13 +70,13 @@ def get_dataset(dataset_name, benchmark_path):
         "msd": lambda: MSD_dataset(benchmark_path),
         "sesoko": lambda: SESOKO_dataset(benchmark_path),
         "squidle": lambda: SESOKO_dataset(benchmark_path),
+        "vitum": lambda: VITUM_dataset(benchmark_path),
         "7scenes": lambda: SEVENSCENES_dataset(benchmark_path),
         "openloris-d400": lambda: OPENLORIS_d400_dataset(benchmark_path),
         "openloris-t265": lambda: OPENLORIS_t265_dataset(benchmark_path),
         "monotum": lambda: MONOTUM_dataset(benchmark_path),
 
         # Development
-        "vitum": lambda: VITUM_dataset(benchmark_path),
         "scannetplusplus": lambda: SCANNETPLUSPLUS_dataset(benchmark_path),
         "lizardisland": lambda: LIZARDISLAND_dataset(benchmark_path),
         "hamlyn": lambda: HAMLYN_dataset(benchmark_path),

--- a/Datasets/get_dataset.py
+++ b/Datasets/get_dataset.py
@@ -69,6 +69,7 @@ def get_dataset(dataset_name, benchmark_path):
         "s3li": lambda: S3LI_dataset(benchmark_path),
         "msd": lambda: MSD_dataset(benchmark_path),
         "sesoko": lambda: SESOKO_dataset(benchmark_path),
+        "squidle": lambda: SESOKO_dataset(benchmark_path),
         "7scenes": lambda: SEVENSCENES_dataset(benchmark_path),
         "openloris-d400": lambda: OPENLORIS_d400_dataset(benchmark_path),
         "openloris-t265": lambda: OPENLORIS_t265_dataset(benchmark_path),

--- a/Datasets/get_dataset.py
+++ b/Datasets/get_dataset.py
@@ -70,7 +70,6 @@ def get_dataset(dataset_name, benchmark_path):
         "s3li": lambda: S3LI_dataset(benchmark_path),
         "msd": lambda: MSD_dataset(benchmark_path),
         "sesoko": lambda: SESOKO_dataset(benchmark_path),
-        "squidle": lambda: SESOKO_dataset(benchmark_path),
         "vitum": lambda: VITUM_dataset(benchmark_path),
         "4seasons": lambda: FOURSEASONS_dataset(benchmark_path),
         "7scenes": lambda: SEVENSCENES_dataset(benchmark_path),

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ To [awesome-slam-datasets](https://github.com/youngguncho/awesome-slam-datasets)
 | [**The KITTI Vision Benchmark Suite**](https://www.cvlibs.net/datasets/kitti/eval_odometry.php)                                 |  📸🏞️🚗 |   `kitti`   |`mono` `stereo` | `pinhole` |
 | [**The EuRoC MAV Dataset**](https://projects.asl.ethz.ch/datasets/doku.php?id=kmavvisualinertialdatasets)                       |  📸🏞️🚁 |   `euroc`   | `mono(-vi)` `stereo(-vi)` | `radtan4` |
 | [**The TUM Visual-Inertial Dataset**](https://cvg.cit.tum.de/data/datasets/visual-inertial-dataset)                             |  📸🏠🤳 |  `vitum`  | `mono` `mono-vi` | `equid4` |
+| [**The 4Seasons Dataset**](https://cvg.cit.tum.de/data/datasets/4seasons-dataset)                                                |  📸🏞️🚗 |  `4seasons`  | `stereo` `stereo-vi` | `pinhole` `equid4` |
 | [**The Replica Dataset**](https://github.com/facebookresearch/Replica-Dataset) - [**iMAP**](https://edgarsucar.github.io/iMAP/) |  💻🏠🤳 |  `replica`  | `mono` `rgbd`  | `pinhole` |
 | [**TartanAir: A Dataset to Push the Limits of Visual SLAM**](https://theairlab.org/tartanair-dataset/)                          |  💻🏞️🤳 | `tartanair` | `mono`  | `pinhole` |
 | [**ICL-NUIM RGB-D Benchmark Dataset**](https://www.doc.ic.ac.uk/~ahanda/VaFRIC/iclnuim.html)                                    |  💻🏠🤳 |   `nuim`    | `mono` `rgbd`  | `pinhole` | 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ To [awesome-slam-datasets](https://github.com/youngguncho/awesome-slam-datasets)
 |:--------------------------------------------------------------------------------------------------------------------------------|:---------:|:-----------:|:----------:|:----------:|
 | [**ETH3D SLAM Benchmarks**](https://www.eth3d.net/slam_datasets)                                                                |  📸🏠🤳 |   `eth`    |`mono` `rgbd`| `pinhole` |
 | [**RGB-D SLAM Dataset and Benchmark**](https://cvg.cit.tum.de/data/datasets/rgbd-dataset)                                       |  📸🏠🤳 |  `rgbdtum`  |`mono` `rgbd`| `radtan5` |
+| [**Monocular Visual Odometry Dataset**](https://cvg.cit.tum.de/data/datasets/mono-dataset)                                      |  📸🏠🤳 |  `monotum`  |`mono`| `pinhole` |
 | [**The KITTI Vision Benchmark Suite**](https://www.cvlibs.net/datasets/kitti/eval_odometry.php)                                 |  📸🏞️🚗 |   `kitti`   |`mono` `stereo` | `pinhole` |
 | [**The EuRoC MAV Dataset**](https://projects.asl.ethz.ch/datasets/doku.php?id=kmavvisualinertialdatasets)                       |  📸🏞️🚁 |   `euroc`   | `mono(-vi)` `stereo(-vi)` | `radtan4` |
 | [**The Replica Dataset**](https://github.com/facebookresearch/Replica-Dataset) - [**iMAP**](https://edgarsucar.github.io/iMAP/) |  💻🏠🤳 |  `replica`  | `mono` `rgbd`  | `pinhole` |
@@ -212,7 +213,7 @@ Handheld / Headmounted / Vehicle / UAV  / Robot / AUV :🤳 / 🥽 / 🚗 / 🚁
 - [ ] Extend `okvis2` and `okvis2-dev` to `rgbd-vi` and `stereo-vi`
 
 ### Datasets
-- [ ] Implement `monotum`
+- [x] Implement `monotum`
 - [ ] Implement `drunkards`
 - [ ] Implement `hamlyn`
 - [ ] Implement `caves`

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ To [awesome-slam-datasets](https://github.com/youngguncho/awesome-slam-datasets)
 | [**Monocular Visual Odometry Dataset**](https://cvg.cit.tum.de/data/datasets/mono-dataset)                                      |  📸🏠🤳 |  `monotum`  |`mono`| `pinhole` |
 | [**The KITTI Vision Benchmark Suite**](https://www.cvlibs.net/datasets/kitti/eval_odometry.php)                                 |  📸🏞️🚗 |   `kitti`   |`mono` `stereo` | `pinhole` |
 | [**The EuRoC MAV Dataset**](https://projects.asl.ethz.ch/datasets/doku.php?id=kmavvisualinertialdatasets)                       |  📸🏞️🚁 |   `euroc`   | `mono(-vi)` `stereo(-vi)` | `radtan4` |
+| [**The TUM Visual-Inertial Dataset**](https://cvg.cit.tum.de/data/datasets/visual-inertial-dataset)                             |  📸🏠🤳 |  `vitum`  | `mono` `mono-vi` | `equid4` |
 | [**The Replica Dataset**](https://github.com/facebookresearch/Replica-Dataset) - [**iMAP**](https://edgarsucar.github.io/iMAP/) |  💻🏠🤳 |  `replica`  | `mono` `rgbd`  | `pinhole` |
 | [**TartanAir: A Dataset to Push the Limits of Visual SLAM**](https://theairlab.org/tartanair-dataset/)                          |  💻🏞️🤳 | `tartanair` | `mono`  | `pinhole` |
 | [**ICL-NUIM RGB-D Benchmark Dataset**](https://www.doc.ic.ac.uk/~ahanda/VaFRIC/iclnuim.html)                                    |  💻🏠🤳 |   `nuim`    | `mono` `rgbd`  | `pinhole` | 

--- a/configs/config_4seasons.yaml
+++ b/configs/config_4seasons.yaml
@@ -1,0 +1,8 @@
+4seasons:
+  - office_loop_1_train
+  - neighborhood_1_train
+  - business_campus_1_train
+  - countryside_1_train
+  - city_loop_1_train
+  - old_town_1_train
+  - parking_garage_1_train

--- a/configs/config_monotum.yaml
+++ b/configs/config_monotum.yaml
@@ -1,0 +1,11 @@
+monotum:
+  - 'sequence_01'
+  - 'sequence_02'
+  - 'sequence_03'
+  - 'sequence_04'
+  - 'sequence_05'
+  - 'sequence_06'
+  - 'sequence_07'
+  - 'sequence_08'
+  - 'sequence_09'
+  - 'sequence_10'

--- a/configs/config_squidle.yaml
+++ b/configs/config_squidle.yaml
@@ -1,5 +1,2 @@
-squidle:
-  #- 'alignment'
-  #- 'ssk16-01_tuna_sand2_20160718_021400_ts2_un_images'
-  #- 'ssk17-01_tuna_sand_20170817_041459_ts_un6k_images'
-  - 'ssk18-01_tuna_sand_20181002_063627_ts_un6k_images'
+sesoko:
+  - ssk18

--- a/configs/config_squidle.yaml
+++ b/configs/config_squidle.yaml
@@ -1,2 +1,5 @@
-sesoko:
-  - ssk18
+squidle:
+  #- 'alignment'
+  #- 'ssk16-01_tuna_sand2_20160718_021400_ts2_un_images'
+  #- 'ssk17-01_tuna_sand_20170817_041459_ts_un6k_images'
+  - 'ssk18-01_tuna_sand_20181002_063627_ts_un6k_images'

--- a/configs/config_vitum.yaml
+++ b/configs/config_vitum.yaml
@@ -1,0 +1,6 @@
+vitum:
+  - corridor1
+  - magistrale1
+  - outdoors1
+  - room1
+  - slides1


### PR DESCRIPTION
## Summary
This PR combines dataset integrations and dataset architecture improvements in VSLAM-LAB:
- add first-class support for Monocular TUM (`monotum`)
- add first-class support for TUM Visual-Inertial (`vitum`)
- add first-class support for 4Seasons (`4seasons`)
- streamline dataset configuration handling via shared abstractions in the base dataset class

## Included changes
- Monotum integration:
  - new dataset implementation under `Datasets/dataset_files`
  - dataset YAML registration and sequence list
  - registration in `Datasets/get_dataset.py`
  - starter config in `configs/config_monotum.yaml`
  - README dataset table update

- TUM VI integration:
  - new dataset implementation under `Datasets/dataset_files`
  - dataset YAML registration and sequence list
  - registration in `Datasets/get_dataset.py`
  - starter config in `configs/config_vitum.yaml`
  - README dataset table update

- 4Seasons integration:
  - new dataset implementation under `Datasets/dataset_files`
  - dataset YAML with sequence-to-recording mapping
  - registration in `Datasets/get_dataset.py`
  - starter config in `configs/config_4seasons.yaml`
  - README dataset table update

- Dataset abstractions:
  - `DatasetVSLAMLab` now stores parsed YAML once as shared config
  - added helper accessors for required/optional keys (`cfg_require`, `cfg_get`)
  - migrated multiple `dataset_files` implementations to remove duplicated YAML reload logic

- Squidle wiring fix:
  - fixed aliasing to SESOKO-backed implementation
  - updated `configs/config_squidle.yaml` to current naming

## Validation
- compile checks for touched dataset modules
- runtime registration checks for `monotum`, `vitum`, `4seasons`
- smoke test completed for `monotum/sequence_01`