### PR TITLE
Add AI skills for VSLAM-LAB

### DIFF
--- a/docs/ai-skills/README.md
+++ b/docs/ai-skills/README.md
@@ -1,0 +1,32 @@
+# VSLAM-LAB AI skills (human guide)
+
+This folder contains small “skill” docs that help an AI assistant work correctly in the VSLAM-LAB repo (paths, schemas, commands, and integration steps).
+
+## What skills exist
+
+- **`skill_vslamlab_framework_overview.md`**: architecture + where things live.
+- **`skill_vslamlab_critical_components.md`**: base classes, registries, YAML schema, required dataset outputs.
+- **`skill_vslamlab_integrate_baseline.md`**: add a new baseline (pixi env/tasks + wrapper class + registry + smoke test).
+- **`skill_vslamlab_integrate_dataset.md`**: add a new dataset (dataset yaml + class + registry + download validation).
+- **`skill_vslamlab_define_experiment_from_prompt.md`**: turn a natural-language request into `configs/config_*.yaml` + `configs/exp_*.yaml`.
+- **`skill_vslamlab_run_evaluate_debug_experiments.md`**: validate/run/evaluate/compare + where logs are + debug checklist.
+
+## How to use / trigger them
+
+You have two simple options:
+
+### 1) Manual (works in any chat)
+
+- Reference the file(s) or folder in your prompt, e.g. `@docs/ai-skills/` or `@docs/ai-skills/skill_vslamlab_integrate_baseline.md`.
+- Then ask for the task, e.g. “integrate baseline X” or “create an exp yaml for …”.
+
+### 2) Cursor auto-rules (recommended for daily work)
+
+- Copy the files into `.cursor/rules/`
+- Rename them from `.md` → `.mdc`
+- Cursor will auto-apply them based on the `globs:` in each file’s frontmatter.
+
+## Handy prompts
+
+- **Define an experiment from text**: “Use `skill_vslamlab_define_experiment_from_prompt.md` to generate `configs/config_*.yaml` + `configs/exp_*.yaml` for: …”
+- **Run + debug**: “Use `skill_vslamlab_run_evaluate_debug_experiments.md` and tell me exactly which `pixi run ...` commands to run; then help interpret failures from logs.”

--- a/docs/ai-skills/skill_vslamlab_critical_components.md
+++ b/docs/ai-skills/skill_vslamlab_critical_components.md
@@ -1,0 +1,79 @@
+---
+description: Critical integration surfaces (base classes, registries, YAML schema, and pixi tasks) for VSLAM-LAB.
+globs:
+  - "pixi.toml"
+  - "vslamlab_gui.py"
+  - "vslamlab_utilities.py"
+  - "Baselines/BaselineVSLAMLab.py"
+  - "Baselines/get_baseline.py"
+  - "Baselines/baseline_files/*.py"
+  - "Datasets/DatasetVSLAMLab.py"
+  - "Datasets/get_dataset.py"
+  - "Datasets/dataset_files/*"
+  - "configs/**/*.yaml"
+  - "path_constants.py"
+---
+
+# Critical components for integration (repo-accurate)
+
+## `pixi.toml` (environments + tasks)
+
+- Baselines are installed/executed through **per-baseline environments** (e.g. `orbslam2`, `dpvo-dev`) defined under `[environments]`.
+- Each baseline environment typically defines tasks under `[feature.<baseline>.tasks]`, commonly:
+  - `git-clone`
+  - `install` (optional depending on baseline)
+  - `execute-mono` / `execute-rgbd` / `execute-stereo` / `execute-mono-vi` / etc.
+- The VSLAM-LAB pipeline entrypoints are exposed as `pixi run ...` tasks under `[feature.vslamlab.tasks]` and dispatch through `vslamlab_gui.py`.
+
+## Base classes you must match
+
+- **`Baselines/BaselineVSLAMLab.py`**:
+  - You implement a concrete baseline class that provides:
+    - `build_execute_command(...)` (typically delegates to `build_execute_command_cpp` or `build_execute_command_python`)
+    - `is_installed()`
+  - VSLAM-LAB execution is ultimately a `pixi run --frozen -e <baseline> execute-<mode> ...` command.
+- **`Datasets/DatasetVSLAMLab.py`**:
+  - You implement a concrete dataset class that provides:
+    - `download_sequence_data(sequence_name)`
+    - `create_rgb_folder(sequence_name)`
+    - `create_rgb_csv(sequence_name)`
+    - `create_calibration_yaml(sequence_name)`
+  - Optional hooks exist (`create_imu_csv`, `create_groundtruth_csv`, `remove_unused_files`).
+
+## Registries (what makes things “discoverable”)
+
+- **Baselines**: `Baselines/get_baseline.py`
+  - Add an import for your new baseline class and add a new key to the `get_baseline_switcher()` mapping.
+- **Datasets**: `Datasets/get_dataset.py`
+  - Add an import and add a new key to the `switcher` mapping in `get_dataset(...)`.
+
+## YAML schema (what `vslamlab_utilities.py` actually reads)
+
+Experiment YAMLs (`configs/exp_*.yaml`) look like:
+
+```yaml
+my_experiment_name:
+  Config: config_easy.yaml        # dataset → sequences mapping file under configs/
+  NumRuns: 10
+  Parameters: { verbose: 0, mode: mono }
+  Module: orbslam2                # baseline key as registered in Baselines/get_baseline.py
+  Ablation: configs/config_ablation.yaml  # optional
+```
+
+Notes:
+
+- The key is **`Module`** (not `Method`).
+- `Parameters` are merged into baseline defaults by `BaselineVSLAMLab.build_execute_command_*`.
+
+## Standard dataset output structure (what integrity checks require)
+
+After `pixi run download-sequence <dataset> <sequence>` the dataset sequence folder must include (see `Datasets/DatasetVSLAMLab.py` integrity checks):
+
+- `<VSLAMLAB_BENCHMARK>/<DATASET_FOLDER>/<sequence>/rgb_0/` (folder)
+- `<...>/<sequence>/rgb.csv` (file)
+- `<...>/<sequence>/calibration.yaml` (file)
+- plus:
+  - `rgb_1/` if the dataset supports `stereo`
+  - `imu_0.csv` if the dataset supports `mono-vi`
+
+Groundtruth is optional depending on dataset; evaluation logic may require it for some comparisons.

--- a/docs/ai-skills/skill_vslamlab_define_experiment_from_prompt.md
+++ b/docs/ai-skills/skill_vslamlab_define_experiment_from_prompt.md
@@ -1,0 +1,119 @@
+---
+description: Convert a natural-language user request into repo-correct VSLAM-LAB experiment config files (config_*.yaml + exp_*.yaml).
+globs:
+  - "configs/**/*.yaml"
+  - "vslamlab_utilities.py"
+  - "vslamlab_gui.py"
+  - "Baselines/get_baseline.py"
+  - "Datasets/get_dataset.py"
+  - "path_constants.py"
+---
+
+# Skill: define an experiment configuration from a user prompt
+
+## What this skill is for
+
+Given a prompt like:
+
+- “Run `orbslam2` on `rgbdtum` `freiburg1_xyz`, 3 runs, mode rgbd, then evaluate.”
+- “Compare `dpvo` vs `droidslam` on `euroc` `MH_01_easy` stereo, 5 runs each.”
+
+Produce ready-to-run VSLAM-LAB YAML files:
+
+- `configs/config_<name>.yaml` (dataset → sequences)
+- `configs/exp_<name>.yaml` (experiment(s) using `Module`, `Config`, `NumRuns`, `Parameters`)
+
+## Ground rules (repo-specific)
+
+- Use the actual schema consumed by `vslamlab_utilities.py`:
+  - experiment keys: `Config`, `NumRuns`, `Module`, `Parameters` (optional: `Ablation`)
+- Baseline and dataset names must match registries:
+  - baselines: `Baselines/get_baseline.py` keys (also surfaced by `pixi run print-baselines`)
+  - datasets: `Datasets/get_dataset.py` keys / dataset YAMLs (also surfaced by `pixi run print-datasets`)
+- Always include `Parameters.mode` unless the intent is truly ambiguous.
+
+## Defaults (when the user prompt is underspecified)
+
+If the user doesn’t specify:
+
+- **Runs**: default `NumRuns: 1`
+- **Mode**: default to `mono` unless the dataset/baseline implies otherwise
+- **Verbose**: default to `verbose: 1` (matches common baseline defaults)
+- **Overwrite**: default to “no overwrite” (user can pass `--overwrite` when running)
+
+State the defaults you chose in the produced YAML (don’t hide them).
+
+## Output format (what to write)
+
+### 1) Config YAML: dataset → sequences
+
+Create `configs/config_<tag>.yaml`:
+
+```yaml
+euroc:
+  - MH_01_easy
+```
+
+Rules:
+
+- One dataset per config is the simplest default.
+- If the user requests multiple datasets, include all under the same config only if you intend to run them together.
+
+### 2) Experiment YAML: one or more experiments
+
+Create `configs/exp_<tag>.yaml`:
+
+```yaml
+my_exp:
+  Config: config_<tag>.yaml
+  NumRuns: 3
+  Module: orbslam2
+  Parameters:
+    mode: rgbd
+    verbose: 1
+```
+
+For comparisons (multiple baselines), emit one experiment block per baseline (same `Config`, same `NumRuns`, baseline-specific `Module` and `Parameters`).
+
+## How to translate a prompt → YAML (step-by-step)
+
+1. **Extract intent**
+   - Baseline(s): single (`orbslam2`) or list (`dpvo` vs `droidslam`)
+   - Dataset: (`euroc`, `rgbdtum`, …)
+   - Sequence(s): names requested
+   - Mode: `mono`, `stereo`, `rgbd`, `mono-vi`, `stereo-vi` (as used in this repo)
+   - Runs: integer
+   - Actions: run only vs run+evaluate vs compare
+
+2. **Normalize names**
+   - Lowercase dataset/baseline keys as used in registries (e.g. `ut-coda`, `rover-t265`).
+   - Keep sequence names as-is (they’re dataset-specific).
+
+3. **Choose file tag + experiment names**
+   - File tag: short + descriptive, e.g. `<dataset>_<seq>_<mode>_<baselines>`
+   - Experiment key names: stable, e.g. `exp_<baseline>_<mode>`
+
+4. **Write `configs/config_<tag>.yaml`**
+   - Put dataset key at top level and list sequences.
+
+5. **Write `configs/exp_<tag>.yaml`**
+   - For each baseline:
+     - set `Module` to the baseline key
+     - set `Parameters.mode` to the chosen mode
+     - include any explicit parameters from the user prompt
+
+6. **Provide the exact run commands**
+   - `pixi run validate-experiment-yaml configs/exp_<tag>.yaml`
+   - `pixi run run-exp configs/exp_<tag>.yaml`
+   - optionally:
+     - `pixi run evaluate-exp configs/exp_<tag>.yaml`
+     - `pixi run compare-exp configs/exp_<tag>.yaml`
+
+## Compatibility guardrails (don’t generate broken configs)
+
+Before finalizing, sanity check:
+
+- Mode requested is supported by baseline (`baseline.modes`) and dataset (`dataset.modes`).
+- Baseline camera models (`baseline.camera_models`) intersect dataset camera models (`dataset.cam_models`).
+
+If a prompt requests an incompatible combo, generate the closest valid alternative and clearly state what changed (e.g. stereo → mono).

--- a/docs/ai-skills/skill_vslamlab_framework_overview.md
+++ b/docs/ai-skills/skill_vslamlab_framework_overview.md
@@ -1,0 +1,44 @@
+---
+description: High-level architecture and “where things live” in VSLAM-LAB.
+globs:
+  - "pixi.toml"
+  - "vslamlab_gui.py"
+  - "vslamlab_utilities.py"
+  - "Baselines/**/*.py"
+  - "Datasets/**/*.py"
+  - "configs/**/*.yaml"
+  - "path_constants.py"
+---
+
+# VSLAM-LAB architecture (context)
+
+## What VSLAM-LAB is
+
+VSLAM-LAB is a framework to **install baselines**, **download/standardize datasets**, **run experiments**, and **evaluate/compare results** through a single `pixi`-driven CLI.
+
+## Core ideas that show up in code
+
+- **Reproducibility via `pixi` environments**: each baseline has its own `pixi` environment (e.g. `orbslam2`, `dpvo-dev`) with tasks like `git-clone`, `install`, and `execute-*` defined in `pixi.toml`.
+- **Standard dataset layout**: datasets are downloaded and standardized into a benchmark folder (`VSLAMLAB_BENCHMARK` in `path_constants.py`) with required files like `rgb.csv` and `calibration.yaml`.
+- **Standardized execution contract**: baselines are run via a wrapper class (`Baselines/BaselineVSLAMLab.py`) that constructs a command and expects an output trajectory file per run.
+
+## Where to look (repo-accurate)
+
+- **CLI entrypoint**: `vslamlab_gui.py` dispatches subcommands.
+- **Pipeline implementation**: `vslamlab_utilities.py` implements `install_baseline`, `download_sequence`, `run_exp`, `evaluate_exp`, `compare_exp`, validation, and experiment log management.
+- **Baseline base class**: `Baselines/BaselineVSLAMLab.py` (build/execute contract + `pixi run --frozen -e <baseline> ...` integration).
+- **Baseline registry**: `Baselines/get_baseline.py` (string name → class instance).
+- **Dataset base class**: `Datasets/DatasetVSLAMLab.py` (download + standardization hooks).
+- **Dataset registry**: `Datasets/get_dataset.py` (string name → class instance).
+- **Configs**: `configs/*.yaml` (experiment YAMLs and dataset/sequence config YAMLs).
+- **Paths**: `path_constants.py` (benchmark/evaluation dirs, filenames, defaults).
+
+## “How do I run it?” (actual tasks in `pixi.toml`)
+
+The main pipeline tasks are:
+
+- `pixi run install-baseline <baseline_name>`
+- `pixi run download-sequence <dataset_name> <sequence_name>`
+- `pixi run run-exp <exp_yaml> [--overwrite]`
+- `pixi run evaluate-exp <exp_yaml> [--overwrite]`
+- `pixi run compare-exp <exp_yaml>`

--- a/docs/ai-skills/skill_vslamlab_integrate_baseline.md
+++ b/docs/ai-skills/skill_vslamlab_integrate_baseline.md
@@ -1,0 +1,99 @@
+---
+description: Skill guide for adding a new SLAM baseline to VSLAM-LAB (pixi env + baseline class + registry + smoke test).
+globs:
+  - "pixi.toml"
+  - "Baselines/BaselineVSLAMLab.py"
+  - "Baselines/get_baseline.py"
+  - "Baselines/baseline_files/*.py"
+  - "vslamlab_gui.py"
+  - "vslamlab_utilities.py"
+  - "configs/*.yaml"
+---
+
+# Skill: integrate a new VSLAM baseline
+
+## What this skill is for
+
+Add a new baseline so it can be:
+
+- installed via `pixi run install-baseline <baseline_name>`
+- selected in experiment YAMLs via `Module: <baseline_name>`
+- executed during `pixi run run-exp <exp_yaml>`
+
+For running/evaluating/debugging the experiment pipeline, see `skill_vslamlab_run_evaluate_debug_experiments.md`.
+
+## Ground rules
+
+- Don’t invent build steps. Use the baseline’s docs or existing baselines in `Baselines/baseline_files/` as patterns.
+- Keep changes minimal: `pixi.toml` + a new `baseline_*.py` + one registry entry in `Baselines/get_baseline.py` is the usual shape.
+
+## Step-by-step (repo-accurate)
+
+### Step 1: Add a `pixi` environment + tasks
+
+In `pixi.toml`:
+
+- Add an environment under `[environments]` (this becomes the baseline name users type):
+  - example pattern: `orbslam2 = { features = ["orbslam2"], solve-group = "orb" }`
+- Add a feature section `[feature.<baseline_name>]`:
+  - define dependencies under `[feature.<baseline_name>.dependencies]`
+  - define tasks under `[feature.<baseline_name>.tasks]`
+    - `git-clone` (required if the baseline is fetched)
+    - `install` (optional)
+    - one or more `execute-*` tasks that match supported modes (e.g. `execute-mono`, `execute-stereo`, `execute-mono-vi`)
+
+#### Verify install
+
+- `pixi run install-baseline <baseline_name>` should clone+install (via `vslamlab_utilities.install_baseline`).
+
+### Step 2: Implement the baseline wrapper class
+
+Create a new file in `Baselines/baseline_files/`, e.g. `baseline_mybaseline.py`.
+
+Implement a class that subclasses `BaselineVSLAMLab`:
+
+- define `self.modes` (e.g. `['mono']`, `['mono','stereo']`, etc.)
+- define `self.camera_models` (what dataset camera models are compatible)
+- implement:
+  - `build_execute_command(self, exp_it, exp, dataset, sequence_name)`:
+    - usually `return super().build_execute_command_cpp(...)` or `..._python(...)`
+  - `is_installed(self) -> tuple[bool, str]`:
+    - follow the patterns in existing baseline files (some are “conda package available”, others check a built binary)
+
+#### Important contract
+
+- The baseline must produce the trajectory file expected by `BaselineVSLAMLab.execute(...)`:
+  - `<exp_folder>/<exp_it>_<TRAJECTORY_FILE_NAME>.csv`
+  - where `TRAJECTORY_FILE_NAME` is defined in `path_constants.py` (default: `KeyFrameTrajectory`)
+
+### Step 3: Register the baseline name
+
+Edit `Baselines/get_baseline.py`:
+
+- add an import for your class
+- add a key in `get_baseline_switcher()`:
+  - `"mybaseline": lambda: MYBASELINE_baseline(),`
+
+#### Verify registry
+
+- `pixi run print-baselines` should list it.
+- `pixi run baseline-info mybaseline` should show default parameters/modes.
+
+### Step 4: Smoke test with a minimal exp YAML
+
+Create a small experiment YAML under `configs/` (or reuse `configs/exp_debug.yaml`) using:
+
+```yaml
+my_smoke_test:
+  Config: config_debug.yaml
+  NumRuns: 1
+  Module: mybaseline
+  Parameters:
+    mode: mono
+    verbose: 1
+```
+
+#### Verify run
+
+- `pixi run run-exp configs/<your_exp>.yaml --overwrite`
+- then `pixi run evaluate-exp configs/<your_exp>.yaml --overwrite` (if your dataset+baseline support evaluation inputs)

--- a/docs/ai-skills/skill_vslamlab_integrate_dataset.md
+++ b/docs/ai-skills/skill_vslamlab_integrate_dataset.md
@@ -1,0 +1,106 @@
+---
+description: Skill guide for adding a new dataset to VSLAM-LAB (dataset class + YAML + registry + download verification).
+globs:
+  - "Datasets/DatasetVSLAMLab.py"
+  - "Datasets/get_dataset.py"
+  - "Datasets/dataset_files/*"
+  - "Datasets/extra-files/*"
+  - "configs/*.yaml"
+  - "vslamlab_gui.py"
+  - "vslamlab_utilities.py"
+  - "path_constants.py"
+---
+
+# Skill: integrate a new dataset
+
+## What this skill is for
+
+Add a new dataset so it can be:
+
+- listed by `pixi run print-datasets`
+- downloadable via `pixi run download-sequence <dataset_name> <sequence_name>`
+- referenced in `configs/config_*.yaml` (dataset → sequence lists)
+
+For running/evaluating/debugging the experiment pipeline, see `skill_vslamlab_run_evaluate_debug_experiments.md`.
+
+## Ground rules
+
+- Don’t guess coordinate frames, time units, or depth scale. State assumptions and validate with small samples.
+- The dataset must satisfy the integrity checks in `Datasets/DatasetVSLAMLab.py` (folders/files that must exist).
+- **Important**: If you intend to use this dataset with `pixi run run-exp`, the run pipeline currently expects a per-sequence `groundtruth.csv` to exist (it is copied unconditionally by `Run/run_functions.py:get_sequence_data_for_evaluation`). If the dataset has no GT, you must still generate a placeholder `groundtruth.csv` (header-only) or `run-exp` will fail.
+
+## Step-by-step (repo-accurate)
+
+### Step 1: Create the dataset YAML (`dataset_<name>.yaml`)
+
+Create `Datasets/dataset_files/dataset_<dataset_name>.yaml` with at least:
+
+- `sequence_names`
+- `rgb_hz`
+- optional: `modes` (e.g. `["mono"]`, `["stereo","mono-vi"]`)
+- optional: `cam_models` (defaults to `["pinhole"]`)
+
+This YAML is read by `Datasets/DatasetVSLAMLab.py` during dataset initialization.
+
+### Step 2: Implement the dataset class
+
+Create a python file in `Datasets/dataset_files/`, e.g. `dataset_<dataset_name>.py`, and implement a class that subclasses `DatasetVSLAMLab`.
+
+You must implement these abstract methods (names are exact in this repo):
+
+- `download_sequence_data(sequence_name)`
+- `create_rgb_folder(sequence_name)`
+- `create_rgb_csv(sequence_name)`
+- `create_calibration_yaml(sequence_name)`
+
+Optional (implement if applicable):
+
+- `create_imu_csv(sequence_name)` for `mono-vi`
+- `create_groundtruth_csv(sequence_name)` if groundtruth exists
+- `remove_unused_files(sequence_name)` to shrink disk usage
+- `get_download_issues(sequence_names)` to surface manual steps / auth problems
+
+Reference patterns:
+
+- the base contract in `Datasets/DatasetVSLAMLab.py`
+- existing datasets in `Datasets/dataset_files/`
+- helper templates in `Datasets/extra-files/`
+
+### Step 3: Register the dataset in the registry
+
+Edit `Datasets/get_dataset.py`:
+
+- add an import for your dataset class
+- add a key in `get_dataset(... )`’s `switcher` mapping:
+  - `"mydataset": lambda: MYDATASET_dataset(benchmark_path),`
+
+#### Verify registry
+
+- `pixi run print-datasets` should list your dataset key.
+
+### Step 4: Add a config YAML that references your sequences
+
+Add sequences to a `configs/config_*.yaml` file:
+
+```yaml
+mydataset:
+  - sequence_01
+  - sequence_02
+```
+
+### Step 5: Download + validate the standardized output
+
+Run:
+
+- `pixi run download-sequence mydataset sequence_01`
+
+Verify the created structure under `VSLAMLAB_BENCHMARK` (from `path_constants.py`) includes:
+
+- `<...>/<sequence>/rgb_0/`
+- `<...>/<sequence>/rgb.csv`
+- `<...>/<sequence>/calibration.yaml`
+- plus `rgb_1/` if `stereo` and `imu_0.csv` if `mono-vi`
+
+If you plan to run experiments (`pixi run run-exp`), also verify:
+
+- `<...>/<sequence>/groundtruth.csv` exists (even if header-only)

--- a/docs/ai-skills/skill_vslamlab_run_evaluate_debug_experiments.md
+++ b/docs/ai-skills/skill_vslamlab_run_evaluate_debug_experiments.md
@@ -1,0 +1,109 @@
+---
+description: Run, evaluate, compare, and debug VSLAM-LAB experiments (configs, logs, overwrite semantics, and common failure points).
+globs:
+  - "pixi.toml"
+  - "vslamlab_gui.py"
+  - "vslamlab_utilities.py"
+  - "Run/**/*.py"
+  - "Evaluate/**/*.py"
+  - "configs/**/*.yaml"
+  - "path_constants.py"
+---
+
+# Skill: run, evaluate, and debug experiments
+
+## What this skill is for
+
+Use this when you already have:
+
+- a baseline key (registered in `Baselines/get_baseline.py`)
+- a dataset key (registered in `Datasets/get_dataset.py`)
+- some sequences listed in a `configs/config_*.yaml`
+
+…and you want to run the pipeline reliably and diagnose failures.
+
+If you want to generate `configs/config_*.yaml` and `configs/exp_*.yaml` from a natural-language request, see `skill_vslamlab_define_experiment_from_prompt.md`.
+
+## The “truth” entrypoints
+
+- CLI dispatcher: `vslamlab_gui.py`
+- Implementation: `vslamlab_utilities.py`
+- Default paths: `path_constants.py` (`VSLAMLAB_BENCHMARK`, `VSLAMLAB_EVALUATION`, defaults)
+
+## Minimal experiment YAML (correct schema)
+
+Create `configs/exp_<name>.yaml` like:
+
+```yaml
+my_exp:
+  Config: config_debug.yaml
+  NumRuns: 1
+  Module: orbslam2
+  Parameters:
+    mode: mono
+    verbose: 1
+```
+
+Notes:
+
+- The key is **`Module`** (baseline), not `Method`.
+- `Config` is a *config YAML filename* under `configs/` that maps dataset → sequences.
+
+## Run / evaluate / compare commands
+
+- Validate config + compatibility:
+  - `pixi run validate-experiment-yaml <exp_yaml>`
+- Run (creates/updates experiment log CSV, installs missing baselines, downloads missing sequences, then executes):
+  - `pixi run run-exp <exp_yaml> [--overwrite]`
+- Evaluate:
+  - `pixi run evaluate-exp <exp_yaml> [--overwrite]`
+- Compare:
+  - `pixi run compare-exp <exp_yaml>`
+- Full pipeline (run + evaluate + compare):
+  - `pixi run vslamlab <exp_yaml> [--overwrite]`
+
+## Where outputs and logs show up
+
+Per experiment name (top-level key in the exp YAML), VSLAM-LAB uses:
+
+- `VSLAMLAB_EVALUATION/<exp_name>/vslamlab_exp_log.csv` as the execution log
+- Per-run command output logs are written by `BaselineVSLAMLab.execute(...)` as:
+  - `.../<exp_it>/system_output_<exp_it>.txt` (exact location depends on the baseline’s `exp_folder`)
+
+## What `--overwrite` actually does
+
+- `--overwrite` triggers `overwrite_exp(exp_yaml)` which deletes prior experiment artifacts under the experiment folder(s) in `VSLAMLAB_EVALUATION`.
+- Running without overwrite will skip work in some cases (notably evaluation can skip if it sees already-evaluated rows and overwrite is false).
+
+## Common pitfall: stale experiment logs after changing config files
+
+`run-exp` iterates the experiment log at `VSLAMLAB_EVALUATION/<exp_name>/vslamlab_exp_log.csv`.  
+If you change `configs/config_*.yaml` (add/remove sequences) but reuse the same experiment name, you can end up with **stale rows** referencing sequences that are no longer in the config.
+
+Fast fix:
+
+- `pixi run overwrite-exp <exp_yaml>`
+- then `pixi run run-exp <exp_yaml>`
+
+## Debug checklist (tight + actionable)
+
+When an experiment fails, the fastest triage path is:
+
+- Baseline name not found:
+  - `pixi run print-baselines`
+  - fix: add to `Baselines/get_baseline.py` (registry)
+- Dataset name / sequence not found:
+  - `pixi run print-datasets`
+  - fix: correct `configs/config_*.yaml` entries or dataset’s `sequence_names`
+- Mode mismatch (`mono`/`stereo`/`rgbd`/`mono-vi`):
+  - `validate-experiment-yaml` checks baseline/dataset compatibility (modes + camera models)
+  - fix: align `Parameters.mode`, baseline `self.modes`, dataset `modes`
+- Baseline installed but runtime fails:
+  - inspect `system_output_*.txt` produced during execution
+  - common fix points:
+    - baseline’s `build_execute_command(...)` arguments
+    - baseline `execute-*` tasks in `pixi.toml`
+    - missing baseline settings yaml (`BaselineVSLAMLab.download_vslamlab_settings`)
+- Dataset “available” check fails after download:
+  - `DatasetVSLAMLab.check_sequence_integrity(...)` requires `rgb_0/`, `rgb.csv`, `calibration.yaml` (+ extras for stereo/vi)
+  - fix: dataset class methods `create_rgb_folder/create_rgb_csv/create_calibration_yaml`

--- a/docs/ai-skills/skill_vslamlab_user_guide.md
+++ b/docs/ai-skills/skill_vslamlab_user_guide.md
@@ -1,0 +1,39 @@
+---
+description: How to use these VSLAM-LAB skill docs with Cursor (rules) and how to prompt effectively.
+globs: []
+---
+
+# VSLAM-LAB skill docs user guide
+
+## Using these files in Cursor
+
+These docs are written so they can be used either as:
+
+- **Standalone docs** (read and follow manually), or
+- **Cursor rules** (auto-applied based on file globs).
+
+If you want Cursor to treat them as rules:
+
+- Copy or symlink them into `.cursor/rules/`
+- Rename to `.mdc` (Cursor rule file extension)
+
+## “Co-pilot” workflow expectation
+
+When integrating baselines/datasets, a good agent workflow is:
+
+- use repo files as truth (`pixi.toml`, `Baselines/*`, `Datasets/*`, `vslamlab_utilities.py`)
+- state any assumptions about external repos / dataset formats
+- ask for the smallest possible verification artifacts (build logs, a few lines of `rgb.csv`, folder listing)
+- for transparency, write the final end-to-end plan into `docs/plans/<topic>.md` before implementation (keep the plan file immutable after; subsequent changes should be tracked as updates/notes rather than silently changing the original plan)
+
+## Recommended prompts (repo-accurate)
+
+### Integrate a new baseline
+
+“I want to integrate **<baseline_name>** into VSLAM-LAB. Here is its repo/docs: **LINK**.  
+Please update `pixi.toml` (env + `git-clone`/`install`/`execute-*` tasks), add `Baselines/baseline_files/baseline_<name>.py`, register it in `Baselines/get_baseline.py`, and give me a minimal `configs/exp_<name>_smoke.yaml` to run with `pixi run run-exp`.”
+
+### Integrate a new dataset
+
+“I want to integrate **<dataset_name>**. Here’s a small sample of its file layout + timestamp format (paste).  
+Please add `Datasets/dataset_files/dataset_<name>.yaml`, implement `Datasets/dataset_files/dataset_<name>.py` (matching `DatasetVSLAMLab` abstract methods), register it in `Datasets/get_dataset.py`, and add a `configs/config_<name>.yaml` for sequences.”

--- a/docs/plans/dataset_integration_tum_mono.md
+++ b/docs/plans/dataset_integration_tum_mono.md
@@ -1,0 +1,142 @@
+# Prompt used (for traceability)
+
+```text
+You are an AI coding agent in the repo /home/a.lunawat/ws/VSLAM-LAB (Linux, bash). Your task is to integrate TUM Mono Dataset (URL: https://cvg.cit.tum.de/data/datasets/mono-dataset ) as a new VSLAM-LAB dataset named tum_mono, end-to-end, using the repo’s dataset integration skill doc as your source of truth.
+
+Use the skills in @docs/ai-skills to refine this prompt to come up with an end to end integration plan with verification of the integration.
+```
+
+# Integrate `tum_mono` dataset (TUM Mono Dataset)
+
+## Overview
+Integrate the TUM Monocular Visual Odometry dataset as a new VSLAM-LAB dataset key `tum_mono`, including download + standardization to the benchmark layout, registration, a smoke config/experiment, and concrete verification steps (download → integrity check → run baseline → evaluate).
+
+## Assumptions (will be validated during implementation)
+- The TUM Mono dataset sequences follow the DSO / TUM monoVO on-disk layout: `images.zip`, `times.txt`, `camera.txt`, plus optional `pcalib.txt` / `vignette.png`.
+- `times.txt` is whitespace-separated with at least `frame_id timestamp exposure_ms` (timestamp is POSIX seconds), per TUM mono dataset / DSO conventions.
+- `camera.txt` follows DSO geometric calibration format (Pinhole / RadTan / EquiDistant / FOV), per DSO README.
+
+## Target: VSLAM-LAB standardized output per sequence
+Under `VSLAMLAB_BENCHMARK/TUM_MONO/<sequence_name>/` we will produce:
+- `rgb_0/` (extracted images)
+- `rgb.csv` (timestamps in ns + relative paths)
+- `calibration.yaml` (camera intrinsics + distortion if present)
+
+## Files to add / change
+- Add `Datasets/dataset_files/dataset_tum_mono.yaml`
+- Add `Datasets/dataset_files/dataset_tum_mono.py`
+- Update dataset registry `Datasets/get_dataset.py`
+- Add sequences config `configs/config_tum_mono.yaml` (smoke subset)
+- Add smoke experiment `configs/exp_tum_mono_smoke.yaml` (for end-to-end verification)
+
+## Implementation plan
+### 1) Dataset YAML
+Create `Datasets/dataset_files/dataset_tum_mono.yaml`:
+- `dataset_name: tum_mono`
+- `modes: ['mono']`
+- `cam_models`: include `['pinhole', 'radtan4', 'equid4', 'fov']` as applicable; final list will be limited to what we actually parse from `camera.txt`.
+- `rgb_hz`: set based on dataset docs (most sequences are ~25–30fps, varies). Since the pipeline uses timestamps from `times.txt`, `rgb_hz` is mainly informational; we’ll set it conservatively (e.g. `30.0`) unless the dataset provides a single canonical FPS.
+- `url_download_root`: base URL for per-sequence zip downloads (from the dataset site).
+- `sequence_names`: include all official sequences (but we will only reference a small smoke subset in `configs/config_tum_mono.yaml`).
+
+Verification:
+- `pixi run print-datasets` should later show `tum_mono` (YAML discoverability is via `Datasets/get_dataset.py`, but this file must exist for dataset init).
+
+### 2) Implement `TUM_MONO_dataset` adapter
+Create `Datasets/dataset_files/dataset_tum_mono.py` implementing the `DatasetVSLAMLab` abstract methods:
+
+- `download_sequence_data(sequence_name)`
+  - Download `<sequence_name>.zip` from `url_download_root` into the dataset folder.
+  - Decompress into `.../TUM_MONO/<sequence_name>/`.
+
+- `create_rgb_folder(sequence_name)`
+  - Extract `images.zip` into a working folder.
+  - Move the extracted images into `<sequence>/rgb_0/`.
+  - Keep original filenames (alphabetical sort defines frame order in many consumers).
+  - Optional (only if needed for consistency): delete the intermediate extracted folder, and optionally remove `images.zip` depending on `BENCHMARK_RETENTION` policy (match how other datasets do this).
+
+- `create_rgb_csv(sequence_name)`
+  - Parse `<sequence>/times.txt`.
+  - For each image in sorted `rgb_0/`, pair with the corresponding `times.txt` row by index.
+  - Write `<sequence>/rgb.csv` with header consistent with other mono datasets:
+    - `ts_rgb_0 (ns)`, `path_rgb_0`
+  - Convert `timestamp_seconds → ts_ns = int(timestamp * 1e9)`.
+
+- `create_calibration_yaml(sequence_name)`
+  - Parse `<sequence>/camera.txt` according to DSO’s “Geometric Calibration File” format.
+  - Populate a single camera entry (since dataset is mono):
+    - `cam_name: rgb_0`
+    - `cam_type: gray` or `rgb` (depending on image encoding; likely gray but we can keep `gray` for VO).
+    - `cam_model: pinhole`
+    - `focal_length: [fx, fy]`
+    - `principal_point: [cx, cy]`
+    - If `camera.txt` is `RadTan ... k1 k2 r1 r2`, set:
+      - `distortion_type: radtan4`
+      - `distortion_coefficients: [k1, k2, r1, r2]`
+    - If `EquiDistant ... k1 k2 k3 k4`, set `distortion_type: equid4` + coeffs.
+    - Set `fps: self.rgb_hz` (informational).
+    - Set `T_BS: identity(4)` (dataset does not provide body frame; standard practice in repo when only a single camera exists).
+  - Write via `DatasetVSLAMLab.write_calibration_yaml(sequence_name=..., rgb=[rgb0])`.
+
+- Optional: `get_download_issues(sequence_names)`
+  - Return a single “complete dataset is large” issue (similar to other datasets) and/or warn if user requests many sequences.
+
+Verification:
+- `pixi run download-sequence tum_mono sequence_01` creates required files/folders.
+- `DatasetVSLAMLab.check_sequence_integrity(...)` returns complete.
+
+### 3) Register dataset
+Update `Datasets/get_dataset.py`:
+- Add `from Datasets.dataset_files.dataset_tum_mono import TUM_MONO_dataset`.
+- Add switcher entry:
+  - `"tum_mono": lambda: TUM_MONO_dataset(benchmark_path),`
+
+Verification:
+- `pixi run print-datasets` lists `tum_mono`.
+
+### 4) Add a smoke config
+Add `configs/config_tum_mono.yaml` with the smoke subset:
+
+```yaml
+tum_mono:
+  - sequence_01
+  - sequence_02
+  - sequence_03
+```
+
+Verification:
+- `pixi run validate-experiment-yaml` on the smoke experiment (next step) passes dataset/sequence existence checks.
+
+### 5) Add an end-to-end smoke experiment
+Add `configs/exp_tum_mono_smoke.yaml` that runs a mono-capable baseline compatible with radtan cameras (e.g. `orbslam3` supports `pinhole/radtan4/radtan5/equid4`).
+
+Example shape (values will mirror repo conventions):
+- `Config: config_tum_mono.yaml`
+- `NumRuns: 1`
+- `Module: orbslam3`
+- `Parameters: { mode: mono, verbose: 0 }` (keep minimal)
+
+Verification:
+- `pixi run validate-experiment-yaml configs/exp_tum_mono_smoke.yaml` succeeds.
+
+## Verification checklist (end-to-end)
+- **Discoverability**: `pixi run print-datasets` includes `tum_mono`.
+- **Download+standardize**: `pixi run download-sequence tum_mono sequence_01` produces:
+  - `.../TUM_MONO/sequence_01/rgb_0/` with images
+  - `.../TUM_MONO/sequence_01/rgb.csv`
+  - `.../TUM_MONO/sequence_01/calibration.yaml`
+- **Integrity check**: re-running download should short-circuit as “available”.
+- **Run**: `pixi run run-exp configs/exp_tum_mono_smoke.yaml`
+- **Evaluate (if groundtruth is available in this dataset integration)**: `pixi run evaluate-exp configs/exp_tum_mono_smoke.yaml --overwrite`
+  - If TUM Mono provides ground truth segments in a separate bundle, we’ll either:
+    - integrate `create_groundtruth_csv` from the official supplementary material, or
+    - scope evaluation to “run-only smoke” (trajectory generated) and mark groundtruth as a follow-up.
+
+## Notes on ground truth
+The TUM Mono dataset site references “supplementary material with ORB-SLAM and DSO results” and Matlab evaluation code. During implementation we will confirm whether per-sequence ground truth poses are directly downloadable and in what format; only then will we implement `create_groundtruth_csv`.
+
+## Learnings (from end-to-end integration)
+- **`run-exp` requires `groundtruth.csv`**: The run pipeline copies `<sequence>/groundtruth.csv` unconditionally (`Run/run_functions.py:get_sequence_data_for_evaluation`). If a dataset has no ground truth, you still need to generate a placeholder `groundtruth.csv` (header-only) or `run-exp` will fail before the baseline starts.
+- **Stale experiment logs can reference removed sequences**: `run-exp` iterates `VSLAM-LAB-Evaluation/<exp_name>/vslamlab_exp_log.csv`. If you change `configs/config_*.yaml` but keep the same experiment name, old rows can remain and cause surprising “missing rgb.csv” errors for sequences no longer in the config. Fix: `pixi run overwrite-exp <exp_yaml>` then `pixi run run-exp <exp_yaml>`.
+- **Pixi sandbox can fail on global cache lock**: When running `pixi run ...` from a sandboxed environment, we saw `failed to acquire global cache lock ... Permission denied` on `~/.cache/rattler/...`. Workaround is to run pixi tasks outside the sandbox or ensure cache directory permissions are correct.
+


### PR DESCRIPTION
- Introduced README.md outlining available AI skills for VSLAM-LAB.
- Added detailed skill documents for integrating baselines and datasets, defining experiments from prompts, and running/evaluating/debugging experiments.
- Included user guide for utilizing these skills effectively with Cursor.
- Each skill document specifies required files, usage instructions, and integration steps to enhance the AI assistant's functionality in the VSLAM-LAB repository.