### PR TITLE
Add step_size parameter to downsample_rgb_frames

### DIFF
--- a/Run/downsample_rgb_frames.py
+++ b/Run/downsample_rgb_frames.py
@@ -36,7 +36,7 @@ def get_rows(rows_idx, rgb_csv):
 
     return df.iloc[idx].to_dict(orient="records")
 
-def downsample_rgb_frames(rgb_csv, max_rgb_count, min_fps, verbose=False):
+def downsample_rgb_frames(rgb_csv, max_rgb_count, min_fps, step_size=None, verbose=False):
 
     csv_path = Path(rgb_csv)  
     df = pd.read_csv(csv_path)     
@@ -56,29 +56,34 @@ def downsample_rgb_frames(rgb_csv, max_rgb_count, min_fps, verbose=False):
     max_interval = 1.0 / min_fps
     min_interval = sequence_duration / max_rgb_count
 
-    if min_interval < max_interval:
-        max_interval = min_interval
-        if verbose:
-            print(f"  Adjusted FPS to: {1.0 / max_interval:.2f} Hz")
+    if step_size is None:
+        mode = "adaptive"
+    else:
+        mode = "fixed"
 
-    step_size = max_interval * actual_fps
-    if step_size < 1:
-        step_size = 1
+    if mode == "adaptive":
+        if min_interval < max_interval:
+            max_interval = min_interval
+
+        step_size = max_interval * actual_fps
+
+        if step_size < 1:
+            step_size = 1
+    else:
+        step_size = float(step_size)
 
     if verbose:
+        print(f"  Mode: {mode}")
         print(f"  Step size: {step_size:.2f}")
 
     # Downsample RGB images
-    if max_rgb_count >= len(rgb_paths):
-        downsampled_paths = rgb_paths
-        downsampled_timestamps = rgb_timestamps
-        downsampled_rows = rows
-    else:
-        downsampled_paths, downsampled_timestamps, downsampled_rows = downsample_rgb(rgb_timestamps, rgb_paths, rows, step_size, max_rgb_count)
-
+    downsampled_paths, downsampled_timestamps, downsampled_rows = downsample_rgb(
+        rgb_timestamps, rgb_paths, rows, step_size, max_rgb_count if max_rgb_count else len(rgb_paths)
+    )
 
     downsampled_duration = (downsampled_timestamps[-1] - downsampled_timestamps[0]) / 1e9
     downsampled_fps = len(downsampled_paths) / downsampled_duration
+
 
     if verbose:
         print("\nDownsampling RGB images:")

--- a/Run/run_functions.py
+++ b/Run/run_functions.py
@@ -68,13 +68,18 @@ def create_rgb_exp_csv(exp, dataset, sequence_name, default_parameters = ""):
     shutil.copy(rgb_csv, rgb_exp_csv)
 
     rgb_idx = 'rgb_idx' in exp.parameters
-    max_rgb = 'max_rgb' in exp.parameters or 'max_rgb' in default_parameters and not rgb_idx
-       
+    step_size = exp.parameters.get("step_size", None)
+    has_max_rgb = 'max_rgb' in exp.parameters or (isinstance(default_parameters, dict) and 'max_rgb' in default_parameters)
+    max_rgb = (has_max_rgb or step_size is not None) and not rgb_idx
+
     if max_rgb or rgb_idx:
         if max_rgb:
-            max_rgb_num = exp.parameters['max_rgb'] if 'max_rgb' in exp.parameters else default_parameters['max_rgb']
+            if has_max_rgb:
+                max_rgb_num = exp.parameters['max_rgb'] if 'max_rgb' in exp.parameters else default_parameters['max_rgb']
+            else:
+                max_rgb_num = float('inf')  
             min_fps = dataset.rgb_hz / 10
-            _, _, downsampled_rows = downsample_rgb_frames(rgb_csv, max_rgb_num, min_fps, True)
+            _, _, downsampled_rows = downsample_rgb_frames(rgb_csv, max_rgb_num, min_fps, step_size, True)
 
         if rgb_idx:
             downsampled_rows = get_rows(


### PR DESCRIPTION
Allows specifying a fixed `step_size` directly in an experiment parameters.

This change:
- Triggers downsampling when `step_size` is set.
- Falls back to `max_rgb_num = inf` when only `step_size` is given.
- Adds `step_size=None` to `downsample_rgb_frames()`:
    - `None` (default): adaptive mode, same as before.
    - a value: fixed mode, constant sampling interval.